### PR TITLE
[lld][ELF] linker script lexer 

### DIFF
--- a/lld/ELF/CMakeLists.txt
+++ b/lld/ELF/CMakeLists.txt
@@ -47,6 +47,7 @@ add_lld_library(lldELF
   InputSection.cpp
   LTO.cpp
   LinkerScript.cpp
+  LinkerScriptLexer.cpp
   MapFile.cpp
   MarkLive.cpp
   OutputSections.cpp

--- a/lld/ELF/LinkerScriptLexer.cpp
+++ b/lld/ELF/LinkerScriptLexer.cpp
@@ -24,11 +24,23 @@ ScriptToken LinkerScriptLexer::getToken() {
     int curChar = getNextChar();
 
     switch (curChar) {
-    case 'A' ... 'Z':
-    case 'a' ... 'z':
+    case ' ':
+    case '\n':
+    case '\t':
+    case '\r':
+      continue; // ignore whitespace
       // TODO
       break;
-    case '0' ... '9':
+    case '0':
+    case '1':
+    case '2':
+    case '3':
+    case '4':
+    case '5':
+    case '6':
+    case '7':
+    case '8':
+    case '9':
       // TODO
       break;
     case '{':
@@ -41,22 +53,33 @@ ScriptToken LinkerScriptLexer::getToken() {
       return ScriptToken::BracektBegin;
     case ')':
       return ScriptToken::BracektEnd;
+    case '=':
+      return ScriptToken::Assign;
+    case '+':
+      return ScriptToken::Plus;
+    default:
+      // default for [A-Z][a-z]
+      break;
     }
   }
 }
 
 unsigned LinkerScriptLexer::getNextChar() {
-  char curChar = *curPtr;
+  char curChar = curStringRef[pos];
   switch (curChar) {
   case 0:
-    if (curPtr != curStringRef.end()) {
-      curPtr++;
+    if (pos < curStringRef.size()) {
+      pos++;
       return 0;
     } else {
       return EOF;
     }
   default:
-    curPtr++;
+    pos++;
     return (unsigned char)curChar;
   }
+}
+
+ScriptToken LinkerScriptLexer::getCommandOrSymbolName() {
+  return ScriptToken::SymbolName;
 }

--- a/lld/ELF/LinkerScriptLexer.cpp
+++ b/lld/ELF/LinkerScriptLexer.cpp
@@ -15,8 +15,48 @@ using namespace llvm;
 using namespace lld;
 using namespace lld::elf;
 
-LinkerScriptLexer::LinkerScriptLexer(MemoryBufferRef MB) {}
+LinkerScriptLexer::LinkerScriptLexer(MemoryBufferRef MB) {
+  curStringRef = MB.getBuffer();
+}
 
-ScriptToken LinkerScriptLexer::getScriptToken() { return ScriptToken::ENTRY; }
+ScriptToken LinkerScriptLexer::getToken() {
+  while (true) {
+    int curChar = getNextChar();
 
-unsigned LinkerScriptLexer::getNextChar() { return 0; }
+    switch (curChar) {
+    case 'A' ... 'Z':
+    case 'a' ... 'z':
+      // TODO
+      break;
+    case '0' ... '9':
+      // TODO
+      break;
+    case '{':
+      return ScriptToken::CurlyBegin;
+    case '}':
+      return ScriptToken::CurlyEnd;
+    case '?':
+      return ScriptToken::QuestionMark;
+    case '(':
+      return ScriptToken::BracektBegin;
+    case ')':
+      return ScriptToken::BracektEnd;
+    }
+  }
+}
+
+unsigned LinkerScriptLexer::getNextChar() {
+  char curChar = *curPtr;
+  switch (curChar) {
+  case 0:
+    if (curPtr != curStringRef.end()) {
+      curPtr++;
+      return 0;
+    } else {
+      return EOF;
+    }
+  default:
+    curPtr++;
+    return (unsigned char)curChar;
+  }
+}

--- a/lld/ELF/LinkerScriptLexer.cpp
+++ b/lld/ELF/LinkerScriptLexer.cpp
@@ -1,0 +1,22 @@
+//===- ScriptParser.cpp ---------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "LinkerScriptLexer.h"
+#include "lld/Common/ErrorHandler.h"
+#include "llvm/ADT/Twine.h"
+#include "llvm/Support/ErrorHandling.h"
+
+using namespace llvm;
+using namespace lld;
+using namespace lld::elf;
+
+LinkerScriptLexer::LinkerScriptLexer(MemoryBufferRef MB) {}
+
+ScriptToken LinkerScriptLexer::getScriptToken() { return ScriptToken::ENTRY; }
+
+unsigned LinkerScriptLexer::getNextChar() { return 0; }

--- a/lld/ELF/LinkerScriptLexer.cpp
+++ b/lld/ELF/LinkerScriptLexer.cpp
@@ -197,7 +197,9 @@ LinkerScriptLexer::TokenInfo LinkerScriptLexer::getQuotedToken() {
 }
 
 LinkerScriptLexer::TokenInfo LinkerScriptLexer::getDigits() {
-  size_t pos = curStringRef.find_first_not_of("0123456789XxHhKkMm");
+  size_t pos = curStringRef.find_first_not_of(
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+      "0123456789");
   if (curStringRef.starts_with_insensitive("0x")) {
     return advanceTokenInfo(ScriptToken::Hexdecimal, pos);
   }

--- a/lld/ELF/LinkerScriptLexer.cpp
+++ b/lld/ELF/LinkerScriptLexer.cpp
@@ -110,7 +110,7 @@ LinkerScriptLexer::TokenInfo LinkerScriptLexer::getSymbolToken() {
   case ',':
     return advanceTokenInfo(ScriptToken::Comma);
   case '_':
-    return advanceTokenInfo(ScriptToken::Underscore);
+    return getCommandOrIdentify();
   case '.':
     return advanceTokenInfo(ScriptToken::Dot);
   case ':':

--- a/lld/ELF/LinkerScriptLexer.cpp
+++ b/lld/ELF/LinkerScriptLexer.cpp
@@ -109,6 +109,12 @@ LinkerScriptLexer::TokenInfo LinkerScriptLexer::getSymbolToken() {
     return advanceTokenInfo(ScriptToken::Semicolon);
   case ',':
     return advanceTokenInfo(ScriptToken::Comma);
+  case '_':
+    return advanceTokenInfo(ScriptToken::Underscore);
+  case '.':
+    return advanceTokenInfo(ScriptToken::Dot);
+  case ':':
+    return advanceTokenInfo(ScriptToken::Colon);
   case '<':
     if (curStringRef.size() > 2 && curStringRef[1] == '<' &&
         curStringRef[2] == '=') {

--- a/lld/ELF/LinkerScriptLexer.cpp
+++ b/lld/ELF/LinkerScriptLexer.cpp
@@ -112,7 +112,7 @@ LinkerScriptLexer::TokenInfo LinkerScriptLexer::getSymbolToken() {
   case '_':
     return getCommandOrIdentifier();
   case '.':
-    return advanceTokenInfo(ScriptToken::Dot);
+    return getCommandOrIdentifier();
   case ':':
     return advanceTokenInfo(ScriptToken::Colon);
   case '*':
@@ -225,6 +225,9 @@ LinkerScriptLexer::TokenInfo LinkerScriptLexer::getCommandOrIdentifier() {
     }
   }
 
+  if (pos == 1 && curStringRef[0] == '.')
+    return advanceTokenInfo(ScriptToken::Dot);
+
   return advanceTokenInfo(getTokenfromKeyword(curStringRef.substr(0, pos)),
                           pos);
 }
@@ -255,6 +258,7 @@ LinkerScriptLexer::getTokenfromKeyword(llvm::StringRef keyword) const {
   KEYWORD(HIDDEN);
   KEYWORD(PROVIDE_HIDDEN);
   KEYWORD(SECTIONS);
+  KEYWORD(BEFORE);
   KEYWORD(EXCLUDE_FILE);
   KEYWORD(KEEP);
   KEYWORD(INPUT_SECTION_FLAGS);

--- a/lld/ELF/LinkerScriptLexer.cpp
+++ b/lld/ELF/LinkerScriptLexer.cpp
@@ -193,7 +193,7 @@ LinkerScriptLexer::TokenInfo LinkerScriptLexer::getDigits() {
   if (curStringRef.starts_with_insensitive("0x")) {
     return advanceTokenInfo(ScriptToken::Hexdecimal, pos);
   }
-  const char c = curStringRef[pos];
+  const char c = curStringRef[pos - 1];
   switch (c) {
   case 'H':
   case 'h':

--- a/lld/ELF/LinkerScriptLexer.cpp
+++ b/lld/ELF/LinkerScriptLexer.cpp
@@ -57,7 +57,7 @@ LinkerScriptLexer::TokenInfo LinkerScriptLexer::getTokenInfo() {
   if (std::isdigit(c))
     return getDigits();
   if (std::isalpha(c))
-    return getCommandOrIdentify();
+    return getCommandOrIdentifier();
   return getSymbolToken();
 }
 
@@ -110,7 +110,7 @@ LinkerScriptLexer::TokenInfo LinkerScriptLexer::getSymbolToken() {
   case ',':
     return advanceTokenInfo(ScriptToken::Comma);
   case '_':
-    return getCommandOrIdentify();
+    return getCommandOrIdentifier();
   case '.':
     return advanceTokenInfo(ScriptToken::Dot);
   case ':':
@@ -209,7 +209,7 @@ LinkerScriptLexer::TokenInfo LinkerScriptLexer::getDigits() {
   };
 }
 
-LinkerScriptLexer::TokenInfo LinkerScriptLexer::getCommandOrIdentify() {
+LinkerScriptLexer::TokenInfo LinkerScriptLexer::getCommandOrIdentifier() {
   // Unquoted token. This is more relaxed than tokens in C-like language,
   // so that you can write "file-name.cpp" as one bare token, for example.
   size_t pos = curStringRef.find_first_not_of(
@@ -221,7 +221,7 @@ LinkerScriptLexer::TokenInfo LinkerScriptLexer::getCommandOrIdentify() {
     StringRef ops = "!~*/+-<>?^:="; // List of operators
     size_t e = curStringRef.find_first_of(ops);
     if (e != StringRef::npos && e != 0) {
-      return advanceTokenInfo(ScriptToken::Identify, e);
+      return advanceTokenInfo(ScriptToken::Identifier, e);
     }
   }
 
@@ -302,6 +302,6 @@ LinkerScriptLexer::getTokenfromKeyword(llvm::StringRef keyword) const {
   } else if (keyword == "extern") {
     return ScriptToken::LS_Extern;
   } else {
-    return ScriptToken::Identify;
+    return ScriptToken::Identifier;
   }
 }

--- a/lld/ELF/LinkerScriptLexer.cpp
+++ b/lld/ELF/LinkerScriptLexer.cpp
@@ -18,10 +18,9 @@ LinkerScriptLexer::LinkerScriptLexer(MemoryBufferRef MB, llvm::SourceMgr &SM,
                                      llvm::SMDiagnostic &Err)
     : MB(MB), ErrorInfo(Err), SM(SM) {
   curStringRef = MB.getBuffer();
-  curPtr = curStringRef.begin();
-  // TODO: set up the start for tok1 and tok2
 }
 
+/*
 bool LinkerScriptLexer::Error(SMLoc ErrorLoc, const Twine &Msg) const {
   ErrorInfo = SM.GetMessage(ErrorLoc, llvm::SourceMgr::DK_Error, Msg);
   return true;
@@ -30,148 +29,30 @@ bool LinkerScriptLexer::Error(SMLoc ErrorLoc, const Twine &Msg) const {
 void LinkerScriptLexer::Warning(SMLoc WarningLoc, const Twine &Msg) const {
   SM.PrintMessage(WarningLoc, llvm::SourceMgr::DK_Warning, Msg);
 }
+*/
 
-ScriptToken LinkerScriptLexer::next() {
-  tok1 = tok2;
-  tok1Pos = tok2Pos;
-  tok1Val = tok2Val;
+// bool LinkerScriptLexer::expect(ScriptToken token) { return token == tok1; }
 
-  tok2 = getToken();
-  return tok1;
+inline LinkerScriptLexer::TokenInfo
+LinkerScriptLexer::advanceTokenInfo(ScriptToken kind, size_t pos = 1) {
+  // TODO: special case for kind == ScriptToken::Error
+  llvm::StringRef valRef = curStringRef.substr(0, pos);
+  curStringRef = curStringRef.substr(pos);
+  return {kind, valRef};
 }
 
-ScriptToken LinkerScriptLexer::peek() { return tok1; }
+LinkerScriptLexer::TokenInfo LinkerScriptLexer::getTokenInfo() {
+  curStringRef = skipComments();
 
-ScriptToken LinkerScriptLexer::peek2() { return tok2; }
-
-bool LinkerScriptLexer::expect(ScriptToken token) { return token == tok1; }
-
-ScriptToken LinkerScriptLexer::getToken() {
-  while (true) {
-    curStringRef = skipComments();
-
-    // Quoted token. Note that double-quote characters are parts of a token
-    // because, in a glob match context, only unquoted tokens are interpreted as
-    // glob patterns. Double-quoted tokens are literal patterns in that context.
-    if (curStringRef.starts_with("\"")) {
-      size_t e = curStringRef.find("\"", 1);
-      if (e == StringRef::npos) {
-        StringRef fileName = MB.getBufferIdentifier();
-        Error(fileName + ": unclosed quote");
-        return ScriptToken::Error;
-      }
-      llvm::StringRef quotedRef = curStringRef.take_front(e + 1);
-      // TODO: need a function to tell if quotedRef is a keyword or not
-      // and return ScriptToken
-      curStringRef = curStringRef.substr(e + 1);
-      continue;
-    }
-
-    const char *curChar = curStringRef.begin();
-    switch (*curChar) {
-    case EOF:
-      return ScriptToken::Eof;
-    case '(':
-      return ScriptToken::BracektBegin;
-    case ')':
-      return ScriptToken::BracektEnd;
-    case '{':
-      return ScriptToken::CurlyBegin;
-    case '}':
-      return ScriptToken::CurlyEnd;
-    case ';':
-      return ScriptToken::Semicolon;
-    case ',':
-      return ScriptToken::Comma;
-    case '<':
-      if (curStringRef.size() > 2 && curStringRef[1] == '<' &&
-          curStringRef[2] == '=') {
-        curStringRef = curStringRef.substr(3);
-        return ScriptToken::RightShiftAssign;
-      }
-      if (curStringRef.size() > 1) {
-        if (curStringRef[1] == '=') {
-          curStringRef = curStringRef.substr(2);
-          return ScriptToken::LessEqual;
-        } else if (curStringRef[1] == '<') {
-          curStringRef = curStringRef.substr(2);
-          return ScriptToken::LeftShift;
-        }
-      }
-      curStringRef = curStringRef.substr(1);
-      return ScriptToken::Less;
-    case '>':
-      if (curStringRef.size() > 2 && curStringRef[1] == '>' &&
-          curStringRef[2] == '=') {
-        curStringRef = curStringRef.substr(3);
-        return ScriptToken::LeftShiftAssign;
-      }
-      if (curStringRef.size() > 1) {
-        if (curStringRef[1] == '=') {
-          curStringRef = curStringRef.substr(2);
-          return ScriptToken::GreaterEqual;
-        } else if (curStringRef[1] == '>') {
-          curStringRef = curStringRef.substr(2);
-          return ScriptToken::RightShift;
-        }
-      }
-      curStringRef = curStringRef.substr(1);
-      return ScriptToken::Greater;
-    case '&':
-      if (curStringRef.size() > 1) {
-        if (curStringRef[1] == '=') {
-          curStringRef = curStringRef.substr(2);
-          return ScriptToken::AndAssign;
-        } else if (curStringRef[1] == '&') {
-          curStringRef = curStringRef.substr(2);
-          return ScriptToken::AndGate;
-        }
-      }
-      curStringRef = curStringRef.substr(1);
-      return ScriptToken::Bitwise;
-    case '^':
-      if (curStringRef.size() > 1) {
-        if (curStringRef[1] == '=') {
-          curStringRef = curStringRef.substr(2);
-          return ScriptToken::AndAssign;
-        }
-      }
-      curStringRef = curStringRef.substr(1);
-      return ScriptToken::Xor;
-    case '|':
-      if (curStringRef.size() > 1) {
-        if (curStringRef[1] == '=') {
-          curStringRef = curStringRef.substr(2);
-          return ScriptToken::OrAssign;
-        } else if (curStringRef[1] == '|') {
-          curStringRef = curStringRef.substr(2);
-          return ScriptToken::OrGate;
-        }
-      }
-      curStringRef = curStringRef.substr(1);
-      return ScriptToken::Or;
-    default:
-      // Unquoted token. This is more relaxed than tokens in C-like language,
-      // so that you can write "file-name.cpp" as one bare token, for example.
-      size_t pos = curStringRef.find_first_not_of(
-          "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
-          "0123456789_.$/\\~=+[]*?-!^:");
-
-      // Quoted strings are literal strings, so we don't want to split it.
-      if (inExpression && !curStringRef.starts_with("\"")) {
-        StringRef ops = "!~*/+-<>?^:="; // List of operators
-        size_t e = curStringRef.find_first_of(ops);
-        if (e != StringRef::npos && e != 0) {
-          curStringRef = curStringRef.substr(e);
-          return ScriptToken::Identify;
-        }
-      }
-      curStringRef = curStringRef.substr(pos);
-      return ScriptToken::Identify;
-    };
-
-    return ScriptToken::Error;
-  }
+  // TODO: make sure the empty situation is not an error
+  if (curStringRef.empty())
+    return advanceTokenInfo(ScriptToken::Eof);
+  const char c = curStringRef.front();
+  if (std::isdigit(c))
+    return getDigits();
+  if (std::isalpha(c))
+    return getCommandOrIdentify();
+  return getSymbolToken();
 }
 
 llvm::StringRef LinkerScriptLexer::skipComments() {
@@ -181,7 +62,7 @@ llvm::StringRef LinkerScriptLexer::skipComments() {
     if (curStringRef.starts_with("/*")) {
       size_t e = curStringRef.find("*/", 2);
       if (e == llvm::StringRef::npos) {
-        Error("Unclosed comment in a linker script");
+        // TODO: Error("Unclosed comment in a linker script");
         return "";
       }
       curStringRef = curStringRef.substr(e + 2);
@@ -202,6 +83,131 @@ llvm::StringRef LinkerScriptLexer::skipComments() {
   }
 }
 
-ScriptToken LinkerScriptLexer::getCommandOrIdentify(size_t pos) {
-  return ScriptToken::Identify;
+LinkerScriptLexer::TokenInfo LinkerScriptLexer::getSymbolToken() {
+  const char c = curStringRef.front();
+  // TODO: single char token needs to substr(1)
+  switch (c) {
+  case EOF:
+    return advanceTokenInfo(ScriptToken::Eof);
+  case '"':
+    return getQuotedToken();
+  case '(':
+    return advanceTokenInfo(ScriptToken::BracektBegin);
+  case ')':
+    return advanceTokenInfo(ScriptToken::BracektEnd);
+  case '{':
+    return advanceTokenInfo(ScriptToken::CurlyBegin);
+  case '}':
+    return advanceTokenInfo(ScriptToken::CurlyEnd);
+  case ';':
+    return advanceTokenInfo(ScriptToken::Semicolon);
+  case ',':
+    return advanceTokenInfo(ScriptToken::Comma);
+  case '<':
+    if (curStringRef.size() > 2 && curStringRef[1] == '<' &&
+        curStringRef[2] == '=') {
+      return advanceTokenInfo(ScriptToken::RightShiftAssign, 3);
+    }
+    if (curStringRef.size() > 1) {
+      if (curStringRef[1] == '=') {
+        return advanceTokenInfo(ScriptToken::LessEqual, 2);
+      } else if (curStringRef[1] == '<') {
+        return advanceTokenInfo(ScriptToken::LeftShift, 2);
+      }
+    }
+    return advanceTokenInfo(ScriptToken::Less);
+  case '>':
+    if (curStringRef.size() > 2 && curStringRef[1] == '>' &&
+        curStringRef[2] == '=') {
+      return advanceTokenInfo(ScriptToken::LeftShiftAssign, 3);
+    }
+    if (curStringRef.size() > 1) {
+      if (curStringRef[1] == '=') {
+        return advanceTokenInfo(ScriptToken::GreaterEqual, 2);
+      } else if (curStringRef[1] == '>') {
+        return advanceTokenInfo(ScriptToken::RightShift, 2);
+      }
+    }
+    return advanceTokenInfo(ScriptToken::Greater);
+  case '&':
+    if (curStringRef.size() > 1) {
+      if (curStringRef[1] == '=') {
+        return advanceTokenInfo(ScriptToken::AndAssign, 2);
+      } else if (curStringRef[1] == '&') {
+        return advanceTokenInfo(ScriptToken::AndGate, 2);
+      }
+    }
+    return advanceTokenInfo(ScriptToken::Bitwise);
+  case '^':
+    if (curStringRef.size() > 1) {
+      if (curStringRef[1] == '=') {
+        return advanceTokenInfo(ScriptToken::AndAssign, 2);
+      }
+    }
+    return advanceTokenInfo(ScriptToken::Xor);
+  case '|':
+    if (curStringRef.size() > 1) {
+      if (curStringRef[1] == '=') {
+        return advanceTokenInfo(ScriptToken::OrAssign, 2);
+      } else if (curStringRef[1] == '|') {
+        return advanceTokenInfo(ScriptToken::OrGate, 2);
+      }
+    }
+    return advanceTokenInfo(ScriptToken::Or);
+  default:
+    return advanceTokenInfo(ScriptToken::Error);
+  }
+}
+
+LinkerScriptLexer::TokenInfo LinkerScriptLexer::getQuotedToken() {
+  // Quoted token. Note that double-quote characters are parts of a token
+  // because, in a glob match context, only unquoted tokens are interpreted as
+  // glob patterns. Double-quoted tokens are literal patterns in that context.
+  size_t e = curStringRef.find("\"", 1);
+  if (e == StringRef::npos) {
+    StringRef fileName = MB.getBufferIdentifier();
+    // TODO: Error(fileName + ": unclosed quote");
+    return advanceTokenInfo(ScriptToken::Error, e);
+  }
+  return advanceTokenInfo(ScriptToken::Quote, e + 1);
+}
+
+LinkerScriptLexer::TokenInfo LinkerScriptLexer::getDigits() {
+  size_t pos = curStringRef.find_first_not_of("0123456789XxHhKkMm");
+  if (curStringRef.starts_with_insensitive("0x")) {
+    return advanceTokenInfo(ScriptToken::Hexdecimal, pos);
+  }
+  const char c = curStringRef[pos];
+  switch (c) {
+  case 'H':
+  case 'h':
+    return advanceTokenInfo(ScriptToken::Hexdecimal_H, pos);
+  case 'K':
+  case 'k':
+    return advanceTokenInfo(ScriptToken::Decimal_K, pos);
+  case 'M':
+  case 'm':
+    return advanceTokenInfo(ScriptToken::Decimal_M, pos);
+  default:
+    return advanceTokenInfo(ScriptToken::Decimal, pos);
+  };
+}
+
+LinkerScriptLexer::TokenInfo LinkerScriptLexer::getCommandOrIdentify() {
+  // Unquoted token. This is more relaxed than tokens in C-like language,
+  // so that you can write "file-name.cpp" as one bare token, for example.
+  size_t pos = curStringRef.find_first_not_of(
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+      "0123456789_.$/\\~=+[]*?-!^:");
+
+  // Quoted strings are literal strings, so we don't want to split it.
+  if (inExpression && !curStringRef.starts_with("\"")) {
+    StringRef ops = "!~*/+-<>?^:="; // List of operators
+    size_t e = curStringRef.find_first_of(ops);
+    if (e != StringRef::npos && e != 0) {
+      curStringRef = curStringRef.substr(e);
+      return advanceTokenInfo(ScriptToken::Identify, e);
+    }
+  }
+  return advanceTokenInfo(ScriptToken::Identify, pos);
 }

--- a/lld/ELF/LinkerScriptLexer.cpp
+++ b/lld/ELF/LinkerScriptLexer.cpp
@@ -119,6 +119,8 @@ LinkerScriptLexer::TokenInfo LinkerScriptLexer::getSymbolToken() {
     return advanceTokenInfo(ScriptToken::Asterisk);
   case '=':
     return advanceTokenInfo(ScriptToken::Assign);
+  case '?':
+    return advanceTokenInfo(ScriptToken::QuestionMark);
   case '+':
     if (curStringRef.size() > 1 && curStringRef[1] == '=')
       return advanceTokenInfo(ScriptToken::PlusAssign, 2);

--- a/lld/ELF/LinkerScriptLexer.cpp
+++ b/lld/ELF/LinkerScriptLexer.cpp
@@ -119,6 +119,14 @@ LinkerScriptLexer::TokenInfo LinkerScriptLexer::getSymbolToken() {
     return advanceTokenInfo(ScriptToken::Asterisk);
   case '=':
     return advanceTokenInfo(ScriptToken::Assign);
+  case '+':
+    if (curStringRef.size() > 1 && curStringRef[1] == '=')
+      return advanceTokenInfo(ScriptToken::PlusAssign, 2);
+    return advanceTokenInfo(ScriptToken::Plus);
+  case '-':
+    if (curStringRef.size() > 1 && curStringRef[1] == '=')
+      return advanceTokenInfo(ScriptToken::MinusAssign, 2);
+    return advanceTokenInfo(ScriptToken::Minus);
   case '<':
     if (curStringRef.size() > 2 && curStringRef[1] == '<' &&
         curStringRef[2] == '=') {
@@ -252,6 +260,7 @@ LinkerScriptLexer::getTokenfromKeyword(llvm::StringRef keyword) const {
   KEYWORD(TARGET);
   KEYWORD(OUTPUT_FORMAT);
   KEYWORD(ASSERT);
+  KEYWORD(CONSTANT);
   KEYWORD(EXTERN);
   KEYWORD(OUTPUT_ARCH);
   KEYWORD(PROVIDE);
@@ -275,6 +284,7 @@ LinkerScriptLexer::getTokenfromKeyword(llvm::StringRef keyword) const {
   KEYWORD(ABSOLUTE);
   KEYWORD(ADDR);
   KEYWORD(ALIGN);
+  KEYWORD(ALIGNOF);
   KEYWORD(DATA_SEGMENT_ALIGN);
   KEYWORD(DATA_SEGMENT_END);
   KEYWORD(DEFINED);

--- a/lld/ELF/LinkerScriptLexer.cpp
+++ b/lld/ELF/LinkerScriptLexer.cpp
@@ -253,6 +253,7 @@ LinkerScriptLexer::getTokenfromKeyword(llvm::StringRef keyword) const {
   KEYWORD(ENTRY);
   KEYWORD(INCLUDE);
   KEYWORD(GROUP);
+  KEYWORD(MEMORY);
   KEYWORD(OUTPUT);
   KEYWORD(SEARCH_DIR);
   KEYWORD(STARTUP);
@@ -290,6 +291,7 @@ LinkerScriptLexer::getTokenfromKeyword(llvm::StringRef keyword) const {
   KEYWORD(DATA_SEGMENT_ALIGN);
   KEYWORD(DATA_SEGMENT_END);
   KEYWORD(DEFINED);
+  KEYWORD(LENGTH);
   KEYWORD(LOADADDR);
   KEYWORD(LOG2CEIL);
   KEYWORD(MAX);

--- a/lld/ELF/LinkerScriptLexer.cpp
+++ b/lld/ELF/LinkerScriptLexer.cpp
@@ -14,9 +14,13 @@ using namespace llvm;
 using namespace lld;
 using namespace lld::elf;
 
-LinkerScriptLexer::LinkerScriptLexer(MemoryBufferRef MB, llvm::SourceMgr &SM,
-                                     llvm::SMDiagnostic &Err)
-    : MB(MB), ErrorInfo(Err), SM(SM) {
+// LinkerScriptLexer::LinkerScriptLexer(MemoryBufferRef MB, llvm::SourceMgr &SM,
+//                                      llvm::SMDiagnostic &Err)
+//     : MB(MB), ErrorInfo(Err), SM(SM) {
+//   curStringRef = MB.getBuffer();
+// }
+
+LinkerScriptLexer::LinkerScriptLexer(MemoryBufferRef MB) : MB(MB) {
   curStringRef = MB.getBuffer();
 }
 

--- a/lld/ELF/LinkerScriptLexer.cpp
+++ b/lld/ELF/LinkerScriptLexer.cpp
@@ -310,6 +310,10 @@ LinkerScriptLexer::getTokenfromKeyword(llvm::StringRef keyword) const {
   KEYWORD(CONSTRUCTORS);
   KEYWORD(MAXPAGESIZE);
   KEYWORD(COMMONPAGESIZE);
+  KEYWORD(BYTE);
+  KEYWORD(SHORT);
+  KEYWORD(LONG);
+  KEYWORD(QUAD);
 
 #undef KEYWORD
 

--- a/lld/ELF/LinkerScriptLexer.cpp
+++ b/lld/ELF/LinkerScriptLexer.cpp
@@ -115,6 +115,10 @@ LinkerScriptLexer::TokenInfo LinkerScriptLexer::getSymbolToken() {
     return advanceTokenInfo(ScriptToken::Dot);
   case ':':
     return advanceTokenInfo(ScriptToken::Colon);
+  case '*':
+    return advanceTokenInfo(ScriptToken::Asterisk);
+  case '=':
+    return advanceTokenInfo(ScriptToken::Assign);
   case '<':
     if (curStringRef.size() > 2 && curStringRef[1] == '<' &&
         curStringRef[2] == '=') {

--- a/lld/ELF/LinkerScriptLexer.h
+++ b/lld/ELF/LinkerScriptLexer.h
@@ -1,0 +1,31 @@
+//===- LinkerScriptLexer.h --------------------------------------------*- C++
+//-*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLD_ELF_LINKER_SCRIPT_Lexer_H
+#define LLD_ELF_LINKER_SCRIPT_Lexer_H
+
+#include "ScriptTokenizer.h"
+#include "lld/Common/LLVM.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/MemoryBufferRef.h"
+
+namespace lld::elf {
+
+class LinkerScriptLexer {
+public:
+  explicit LinkerScriptLexer(MemoryBufferRef MB);
+  ScriptToken getScriptToken();
+
+private:
+  size_t pos = 0;
+  unsigned getNextChar();
+};
+} // namespace lld::elf
+
+#endif // LLD_ELF_LINKER_SCRIPT_Lexer_H

--- a/lld/ELF/LinkerScriptLexer.h
+++ b/lld/ELF/LinkerScriptLexer.h
@@ -28,6 +28,9 @@ private:
   unsigned getNextChar();
 
   ScriptToken getToken();
+  ScriptToken getIdentify();
+  ScriptToken getArithmeticOrAssignment();
+  ScriptToken getCommandOrSymbolName();
 };
 } // namespace lld::elf
 

--- a/lld/ELF/LinkerScriptLexer.h
+++ b/lld/ELF/LinkerScriptLexer.h
@@ -13,20 +13,36 @@
 #include "ScriptTokenizer.h"
 #include "lld/Common/LLVM.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/Twine.h"
 #include "llvm/Support/MemoryBufferRef.h"
+#include "llvm/Support/SMLoc.h"
+#include "llvm/Support/SourceMgr.h"
 
 namespace lld::elf {
+class SMDiagnostic;
+class SourceMgr;
 
 class LinkerScriptLexer {
 public:
-  explicit LinkerScriptLexer(MemoryBufferRef MB);
+  explicit LinkerScriptLexer(MemoryBufferRef MB, llvm::SourceMgr &SM,
+                             llvm::SMDiagnostic &Err);
+  llvm::SMLoc getLoc() const { return llvm::SMLoc::getFromPointer(tokStart); }
+  bool Error(llvm::SMLoc ErrorLoc, const llvm::Twine &Msg) const;
+  bool Error(const llvm::Twine &Msg) const { return Error(getLoc(), Msg); }
+  void Warning(llvm::SMLoc WarningLoc, const llvm::Twine &Msg) const;
+  void Warning(const Twine &Msg) const { return Warning(getLoc(), Msg); }
 
 private:
+  llvm::SMDiagnostic &ErrorInfo;
+  llvm::SourceMgr &SM;
   const char *curPtr;
   llvm::StringRef curStringRef;
+
+  const char *tokStart;
   size_t pos = 0;
   unsigned getNextChar();
 
+  void skipComment();
   ScriptToken getToken();
   ScriptToken getIdentify();
   ScriptToken getArithmeticOrAssignment();

--- a/lld/ELF/LinkerScriptLexer.h
+++ b/lld/ELF/LinkerScriptLexer.h
@@ -20,11 +20,14 @@ namespace lld::elf {
 class LinkerScriptLexer {
 public:
   explicit LinkerScriptLexer(MemoryBufferRef MB);
-  ScriptToken getScriptToken();
 
 private:
+  const char *curPtr;
+  llvm::StringRef curStringRef;
   size_t pos = 0;
   unsigned getNextChar();
+
+  ScriptToken getToken();
 };
 } // namespace lld::elf
 

--- a/lld/ELF/LinkerScriptLexer.h
+++ b/lld/ELF/LinkerScriptLexer.h
@@ -34,24 +34,36 @@ public:
   void Warning(llvm::SMLoc WarningLoc, const llvm::Twine &Msg) const;
   void Warning(const Twine &Msg) const { return Warning(getLoc(), Msg); }
 
-  const std::string &getStrVal() const { return strVal; }
+  ScriptToken next();  // update tok1 and tok2
+  ScriptToken peek();  // return tok1
+  ScriptToken peek2(); // return tok2
 
-  void checkToken(ScriptToken token);
+  const std::string &getTok1Val() const { return tok1Val; }
+  const std::string &getTok2Val() const { return tok2Val; }
+
+  bool expect(ScriptToken token); // check if tok1 matches argument token
+  bool inExpression = false;
 
 private:
   llvm::SMDiagnostic &ErrorInfo;
   llvm::SourceMgr &SM;
+
   const char *curPtr;
   llvm::MemoryBufferRef MB;
+
   llvm::StringRef curStringRef;
-  std::string strVal;
+  ScriptToken tok1;
+  ScriptToken tok2;
+  size_t tok1Pos = 0;
+  size_t tok2Pos = 0;
+  std::string tok1Val;
+  std::string tok2Val;
 
   const char *tokStart;
 
   llvm::StringRef skipComments();
   ScriptToken getToken();
-  ScriptToken getArithmeticOrAssignment();
-  ScriptToken getCommandOrSymbolName();
+  ScriptToken getCommandOrIdentify(size_t pos);
 };
 } // namespace lld::elf
 

--- a/lld/ELF/LinkerScriptLexer.h
+++ b/lld/ELF/LinkerScriptLexer.h
@@ -26,11 +26,15 @@ class LinkerScriptLexer {
 public:
   explicit LinkerScriptLexer(MemoryBufferRef MB, llvm::SourceMgr &SM,
                              llvm::SMDiagnostic &Err);
-  llvm::SMLoc getLoc() const { return llvm::SMLoc::getFromPointer(tokStart); }
+  llvm::SMLoc getLoc() const {
+    return llvm::SMLoc::getFromPointer(curStringRef.begin());
+  }
   bool Error(llvm::SMLoc ErrorLoc, const llvm::Twine &Msg) const;
   bool Error(const llvm::Twine &Msg) const { return Error(getLoc(), Msg); }
   void Warning(llvm::SMLoc WarningLoc, const llvm::Twine &Msg) const;
   void Warning(const Twine &Msg) const { return Warning(getLoc(), Msg); }
+
+  const std::string &getStrVal() const { return strVal; }
 
   void checkToken(ScriptToken token);
 
@@ -40,6 +44,7 @@ private:
   const char *curPtr;
   llvm::MemoryBufferRef MB;
   llvm::StringRef curStringRef;
+  std::string strVal;
 
   const char *tokStart;
 

--- a/lld/ELF/LinkerScriptLexer.h
+++ b/lld/ELF/LinkerScriptLexer.h
@@ -7,8 +7,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef LLD_ELF_LINKER_SCRIPT_Lexer_H
-#define LLD_ELF_LINKER_SCRIPT_Lexer_H
+#ifndef LLD_ELF_LINKER_SCRIPT_LEXER_H
+#define LLD_ELF_LINKER_SCRIPT_LEXER_H
 
 #include "ScriptTokenizer.h"
 #include "lld/Common/LLVM.h"
@@ -32,22 +32,22 @@ public:
   void Warning(llvm::SMLoc WarningLoc, const llvm::Twine &Msg) const;
   void Warning(const Twine &Msg) const { return Warning(getLoc(), Msg); }
 
+  void checkToken(ScriptToken token);
+
 private:
   llvm::SMDiagnostic &ErrorInfo;
   llvm::SourceMgr &SM;
   const char *curPtr;
+  llvm::MemoryBufferRef MB;
   llvm::StringRef curStringRef;
 
   const char *tokStart;
-  size_t pos = 0;
-  unsigned getNextChar();
 
-  void skipComment();
+  llvm::StringRef skipComments();
   ScriptToken getToken();
-  ScriptToken getIdentify();
   ScriptToken getArithmeticOrAssignment();
   ScriptToken getCommandOrSymbolName();
 };
 } // namespace lld::elf
 
-#endif // LLD_ELF_LINKER_SCRIPT_Lexer_H
+#endif // LLD_ELF_LINKER_SCRIPT_LEXER_H

--- a/lld/ELF/LinkerScriptLexer.h
+++ b/lld/ELF/LinkerScriptLexer.h
@@ -26,44 +26,46 @@ class LinkerScriptLexer {
 public:
   explicit LinkerScriptLexer(MemoryBufferRef MB, llvm::SourceMgr &SM,
                              llvm::SMDiagnostic &Err);
-  llvm::SMLoc getLoc() const {
+  struct TokenInfo {
+    ScriptToken kind;
+    llvm::StringRef val;
+  };
+
+  // LLVM SourceMgr and SMDiagnostic cannot be used now since
+  // ctx CommonLinkerContext has ownership of all MemoryBuffer
+  // by using SmallVector<MemoryBuffer>> memoryBuffers in ELF/Config.h
+  /*llvm::SMLoc getLoc() const {
     return llvm::SMLoc::getFromPointer(curStringRef.begin());
   }
+
   bool Error(llvm::SMLoc ErrorLoc, const llvm::Twine &Msg) const;
   bool Error(const llvm::Twine &Msg) const { return Error(getLoc(), Msg); }
   void Warning(llvm::SMLoc WarningLoc, const llvm::Twine &Msg) const;
-  void Warning(const Twine &Msg) const { return Warning(getLoc(), Msg); }
-
-  ScriptToken next();  // update tok1 and tok2
-  ScriptToken peek();  // return tok1
-  ScriptToken peek2(); // return tok2
-
-  const std::string &getTok1Val() const { return tok1Val; }
-  const std::string &getTok2Val() const { return tok2Val; }
+  void Warning(const Twine &Msg) const { return Warning(getLoc(), Msg); }*/
 
   bool expect(ScriptToken token); // check if tok1 matches argument token
   bool inExpression = false;
 
+  // TODO: rewrite next(), peek(), and peek2() since TokenInfo change
+
 private:
   llvm::SMDiagnostic &ErrorInfo;
   llvm::SourceMgr &SM;
-
-  const char *curPtr;
   llvm::MemoryBufferRef MB;
-
   llvm::StringRef curStringRef;
-  ScriptToken tok1;
-  ScriptToken tok2;
-  size_t tok1Pos = 0;
-  size_t tok2Pos = 0;
-  std::string tok1Val;
-  std::string tok2Val;
 
-  const char *tokStart;
+  // ScriptToken tok1;
+  // ScriptToken tok2;
+  // size_t tok1Pos = 0;
+  // size_t tok2Pos = 0;
 
   llvm::StringRef skipComments();
-  ScriptToken getToken();
-  ScriptToken getCommandOrIdentify(size_t pos);
+  TokenInfo advanceTokenInfo(ScriptToken kind, size_t pos);
+  TokenInfo getTokenInfo();
+  TokenInfo getSymbolToken();
+  TokenInfo getQuotedToken();
+  TokenInfo getDigits();
+  TokenInfo getCommandOrIdentify();
 };
 } // namespace lld::elf
 

--- a/lld/ELF/LinkerScriptLexer.h
+++ b/lld/ELF/LinkerScriptLexer.h
@@ -26,10 +26,6 @@ class LinkerScriptLexer {
 public:
   explicit LinkerScriptLexer(MemoryBufferRef MB, llvm::SourceMgr &SM,
                              llvm::SMDiagnostic &Err);
-  struct TokenInfo {
-    ScriptToken kind;
-    llvm::StringRef val;
-  };
 
   // LLVM SourceMgr and SMDiagnostic cannot be used now since
   // ctx CommonLinkerContext has ownership of all MemoryBuffer
@@ -47,17 +43,21 @@ public:
   bool inExpression = false;
 
   // TODO: rewrite next(), peek(), and peek2() since TokenInfo change
+  void advanceLexer();
+  const ScriptToken getTokenKind() const { return curToken.kind; };
+  llvm::StringRef getTokenStringRef() const { return curToken.val; };
 
 private:
+  struct TokenInfo {
+    ScriptToken kind;
+    llvm::StringRef val;
+  };
+
+  TokenInfo curToken;
   llvm::SMDiagnostic &ErrorInfo;
   llvm::SourceMgr &SM;
   llvm::MemoryBufferRef MB;
   llvm::StringRef curStringRef;
-
-  // ScriptToken tok1;
-  // ScriptToken tok2;
-  // size_t tok1Pos = 0;
-  // size_t tok2Pos = 0;
 
   llvm::StringRef skipComments();
   TokenInfo advanceTokenInfo(ScriptToken kind, size_t pos);
@@ -66,6 +66,7 @@ private:
   TokenInfo getQuotedToken();
   TokenInfo getDigits();
   TokenInfo getCommandOrIdentify();
+  ScriptToken getTokenfromKeyword(llvm::StringRef keyword) const;
 };
 } // namespace lld::elf
 

--- a/lld/ELF/LinkerScriptLexer.h
+++ b/lld/ELF/LinkerScriptLexer.h
@@ -24,8 +24,10 @@ class SourceMgr;
 
 class LinkerScriptLexer {
 public:
-  explicit LinkerScriptLexer(MemoryBufferRef MB, llvm::SourceMgr &SM,
-                             llvm::SMDiagnostic &Err);
+  // explicit LinkerScriptLexer(MemoryBufferRef MB, llvm::SourceMgr &SM,
+  //                            llvm::SMDiagnostic &Err);
+
+  explicit LinkerScriptLexer(MemoryBufferRef MB);
 
   // LLVM SourceMgr and SMDiagnostic cannot be used now since
   // ctx CommonLinkerContext has ownership of all MemoryBuffer
@@ -54,8 +56,8 @@ private:
   };
 
   TokenInfo curToken;
-  llvm::SMDiagnostic &ErrorInfo;
-  llvm::SourceMgr &SM;
+  // llvm::SMDiagnostic &ErrorInfo;
+  // llvm::SourceMgr &SM;
   llvm::MemoryBufferRef MB;
   llvm::StringRef curStringRef;
 

--- a/lld/ELF/LinkerScriptLexer.h
+++ b/lld/ELF/LinkerScriptLexer.h
@@ -67,7 +67,7 @@ private:
   TokenInfo getSymbolToken();
   TokenInfo getQuotedToken();
   TokenInfo getDigits();
-  TokenInfo getCommandOrIdentify();
+  TokenInfo getCommandOrIdentifier();
   ScriptToken getTokenfromKeyword(llvm::StringRef keyword) const;
 };
 } // namespace lld::elf

--- a/lld/ELF/LinkerScriptLexer.h
+++ b/lld/ELF/LinkerScriptLexer.h
@@ -46,7 +46,7 @@ public:
 
   // TODO: rewrite next(), peek(), and peek2() since TokenInfo change
   void advanceLexer();
-  const ScriptToken getTokenKind() const { return curToken.kind; };
+  ScriptToken getTokenKind() const { return curToken.kind; };
   llvm::StringRef getTokenStringRef() const { return curToken.val; };
 
 private:

--- a/lld/ELF/ScriptTokenizer.h
+++ b/lld/ELF/ScriptTokenizer.h
@@ -15,7 +15,7 @@
 
 namespace lld {
 namespace elf {
-enum Tokens {
+enum ScriptToken {
   ENTRY,
 
   // Commands Files
@@ -60,9 +60,7 @@ enum Tokens {
   INFO,
 
   // Output Section
-  OUTPUT,
   OVERWRITE_SECTIONS,
-  ALIGN,
   SUBALIGN,
   ONLY_IF_RO,
   ONLY_IF_RW,
@@ -145,7 +143,7 @@ enum Tokens {
   RightShiftAssign, // >>=
   BitWiseAssign,    // &=
   BarAssign         // |=
-}
+};
 } // namespace elf
 } // namespace lld
 

--- a/lld/ELF/ScriptTokenizer.h
+++ b/lld/ELF/ScriptTokenizer.h
@@ -1,0 +1,153 @@
+//===- ScriptLexer.h --------------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLD_ELF_SCRIPT_TOKENIZER_H
+#define LLD_ELF_SCRIPT_TOKENIZER_H
+
+namespace lld::elf {
+enum CommandTokens {
+  // Entry point
+  ENTRY, // ENTRY
+
+  // Commands Files
+  INCLUDE,
+  INPUT,
+  GROUP,
+  OUTPUT,
+  SEARCH_DIR,
+  STARTUP,
+
+  INSERT, // TODO
+  AFTER,  // TODO
+
+  // Commands for object file formats
+  OUTPUT_FORMAT,
+  TARGET,
+
+  // Other linker script commands
+  ASSERT,
+  EXTERN,
+  // FORCE_COMMON_ALLOCATION
+  // INHIBIT_COMMON_ALLOCATION
+  // NOCROSSREFS
+  OUTPUT_ARCH
+
+      // Assignment
+      PROVIDE,
+  HIDDEN,
+  PROVIDE_HIDDEN,
+
+  // Section Command
+  SECTIONS,
+  // Input Section
+  EXCLUDE_FILE,
+  KEEP,
+  INPUT_SECTION_FLAGS,
+
+  // Read section
+  OVERLAY,
+  NOLOAD,
+  COPY,
+  INFO
+
+      // Output Section
+      OUTPUT,
+
+  OVERWRITE_SECTIONS // TODO
+
+      ALIGN, // TODO
+  SUBALIGN,
+  ONLY_IF_RO,
+  ONLY_IF_RW,
+  FILL, // TODO
+  SORT, //
+
+  // Builtin Functions
+  ABSOLUTE,
+  ADDR,
+  ALIGN,
+  // BLOCK, // synonym for ALIGN for compatibility with older linker script
+  DATA_SEGMENT_ALIGN,
+  DATA_SEGMENT_END,
+  DEFINED,
+  LOADADDR,
+  LOG2CEIL, // TODO
+  MAX,
+  MIN,
+  ORIGIN,        // TODO
+  SEGMENT_START, // TODO
+  // NEXT, // This function is closely related to ALIGN(exp); unless you use the
+  // MEMORY command to define discontinuous memory for the output file, the two
+  // functions are equivalent.
+  SIZEOF,
+  SIZEOF_HEADERS
+
+      // PHDRS Command
+      FILEHDR,
+  PHDRS,
+  AT,
+  FLAGS,
+
+  // Version Command
+  VERSION,
+
+  REGION_ALIAS   // TODO
+      AS_NEEDED, // TODO
+  CONSTRUCTORS,  // TODO: readsort?
+}
+
+enum labelTokens {
+  Local,  // local
+  Global, // global
+  Extern, // extern
+}
+
+enum TargetType {
+  ELF,
+  Binary,
+  Error
+}
+
+enum SymbolTokens {
+  CurlyBegin,   // {
+  CurlyEnd,     // }
+  BracektBegin, // (
+  BracektEnd,   // )
+  Comma,        // ,
+  Semicolon,    // ;
+  Colon,        // :
+  Asterisk,     // *
+  QuestionMark, // ?
+  Bacckslash,   // "\"
+  Slash,        // /
+  Greater       // >
+      Less,     // <
+  Minus,        // -
+  Plus,         // +
+  Bitwise,      // &
+  Not,          // ^
+  VerticalBar,  // |
+  PercentSign,  // %
+  // TODO:: operator
+}
+
+enum AssignmentSymbols {
+  // Assignmemnt
+  Assign,           // =
+  PlusAssign,       // +=
+  MinussAssign,     // -=
+  MulAssign,        // *=
+  DivAssign,        // /=
+  LeftShiftAssign,  // <<=
+  RightShiftAssign, // >>=
+  BitWiseAssign,    // &=
+  BarAssign         // |=
+}
+} // namespace lld::elf
+
+#endif // LLD_ELF_SCRIPT_TOKENIZER_H

--- a/lld/ELF/ScriptTokenizer.h
+++ b/lld/ELF/ScriptTokenizer.h
@@ -15,7 +15,7 @@
 
 namespace lld {
 namespace elf {
-enum ScriptToken {
+enum class ScriptToken {
   ENTRY,
 
   // Commands Files
@@ -112,6 +112,9 @@ enum ScriptToken {
   ELF,
   Binary,
   Error,
+
+  SymbolName,
+  FileName,
 
   CurlyBegin,   // {
   CurlyEnd,     // }

--- a/lld/ELF/ScriptTokenizer.h
+++ b/lld/ELF/ScriptTokenizer.h
@@ -5,14 +5,18 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+//
+// This file defines the nums for LinkerScript lexer
+//
+//===----------------------------------------------------------------------===//
 
 #ifndef LLD_ELF_SCRIPT_TOKENIZER_H
 #define LLD_ELF_SCRIPT_TOKENIZER_H
 
-namespace lld::elf {
-enum CommandTokens {
-  // Entry point
-  ENTRY, // ENTRY
+namespace lld {
+namespace elf {
+enum Tokens {
+  ENTRY,
 
   // Commands Files
   INCLUDE,
@@ -22,8 +26,8 @@ enum CommandTokens {
   SEARCH_DIR,
   STARTUP,
 
-  INSERT, // TODO
-  AFTER,  // TODO
+  INSERT,
+  AFTER,
 
   // Commands for object file formats
   OUTPUT_FORMAT,
@@ -35,15 +39,15 @@ enum CommandTokens {
   // FORCE_COMMON_ALLOCATION
   // INHIBIT_COMMON_ALLOCATION
   // NOCROSSREFS
-  OUTPUT_ARCH
+  OUTPUT_ARCH,
 
-      // Assignment
-      PROVIDE,
+  // Assignment
+  PROVIDE,
   HIDDEN,
   PROVIDE_HIDDEN,
 
-  // Section Command
   SECTIONS,
+
   // Input Section
   EXCLUDE_FILE,
   KEEP,
@@ -53,19 +57,17 @@ enum CommandTokens {
   OVERLAY,
   NOLOAD,
   COPY,
-  INFO
+  INFO,
 
-      // Output Section
-      OUTPUT,
-
-  OVERWRITE_SECTIONS // TODO
-
-      ALIGN, // TODO
+  // Output Section
+  OUTPUT,
+  OVERWRITE_SECTIONS,
+  ALIGN,
   SUBALIGN,
   ONLY_IF_RO,
   ONLY_IF_RW,
-  FILL, // TODO
-  SORT, //
+  FILL,
+  SORT,
 
   // Builtin Functions
   ABSOLUTE,
@@ -76,19 +78,20 @@ enum CommandTokens {
   DATA_SEGMENT_END,
   DEFINED,
   LOADADDR,
-  LOG2CEIL, // TODO
+
+  LOG2CEIL,
   MAX,
   MIN,
-  ORIGIN,        // TODO
-  SEGMENT_START, // TODO
+  ORIGIN,
+  SEGMENT_START,
   // NEXT, // This function is closely related to ALIGN(exp); unless you use the
   // MEMORY command to define discontinuous memory for the output file, the two
   // functions are equivalent.
   SIZEOF,
-  SIZEOF_HEADERS
+  SIZEOF_HEADERS,
 
-      // PHDRS Command
-      FILEHDR,
+  // PHDRS Command
+  FILEHDR,
   PHDRS,
   AT,
   FLAGS,
@@ -96,24 +99,22 @@ enum CommandTokens {
   // Version Command
   VERSION,
 
-  REGION_ALIAS   // TODO
-      AS_NEEDED, // TODO
-  CONSTRUCTORS,  // TODO: readsort?
-}
+  REGION_ALIAS,
+  AS_NEEDED,
+  CONSTRUCTORS,
 
-enum labelTokens {
+  // Symbolic Constants
+  MAXPAGESIZE,
+  COMMONPAGESIZE,
+
   Local,  // local
   Global, // global
   Extern, // extern
-}
 
-enum TargetType {
   ELF,
   Binary,
-  Error
-}
+  Error,
 
-enum SymbolTokens {
   CurlyBegin,   // {
   CurlyEnd,     // }
   BracektBegin, // (
@@ -125,18 +126,15 @@ enum SymbolTokens {
   QuestionMark, // ?
   Bacckslash,   // "\"
   Slash,        // /
-  Greater       // >
-      Less,     // <
+  Greater,      // >
+  Less,         // <
   Minus,        // -
   Plus,         // +
   Bitwise,      // &
   Not,          // ^
   VerticalBar,  // |
   PercentSign,  // %
-  // TODO:: operator
-}
 
-enum AssignmentSymbols {
   // Assignmemnt
   Assign,           // =
   PlusAssign,       // +=
@@ -148,6 +146,7 @@ enum AssignmentSymbols {
   BitWiseAssign,    // &=
   BarAssign         // |=
 }
-} // namespace lld::elf
+} // namespace elf
+} // namespace lld
 
 #endif // LLD_ELF_SCRIPT_TOKENIZER_H

--- a/lld/ELF/ScriptTokenizer.h
+++ b/lld/ELF/ScriptTokenizer.h
@@ -114,8 +114,7 @@ enum class ScriptToken {
   Error,
   Eof,
 
-  SymbolName,
-  FileName,
+  Identify,
 
   CurlyBegin,   // {
   CurlyEnd,     // }
@@ -133,8 +132,8 @@ enum class ScriptToken {
   Minus,        // -
   Plus,         // +
   Bitwise,      // &
-  Not,          // ^
-  VerticalBar,  // |
+  Xor,          // ^
+  Or,           // |
   PercentSign,  // %
 
   // Assignmemnt
@@ -145,16 +144,19 @@ enum class ScriptToken {
   DivAssign,        // /=
   LeftShiftAssign,  // <<=
   RightShiftAssign, // >>=
-  BitWiseAssign,    // &=
-  BarAssign,        // |=
+  AndAssign,        // &=
+  OrAssign,         // |=
+  XorAssign,        // ^=
 
   // operator token
-  NotEqual,   // !=
-  Equal,      // ==
-  GreatEqual, // >=
-  LessEqual,  // <=
-  LeftShift,  // <<
-  RightShift, // >>
+  NotEqual,     // !=
+  Equal,        // ==
+  GreaterEqual, // >=
+  LessEqual,    // <=
+  LeftShift,    // <<
+  RightShift,   // >>
+  AndGate,      // &&
+  OrGate,       // ||
 };
 } // namespace elf
 } // namespace lld

--- a/lld/ELF/ScriptTokenizer.h
+++ b/lld/ELF/ScriptTokenizer.h
@@ -16,102 +16,103 @@
 namespace lld {
 namespace elf {
 enum class ScriptToken {
-  ENTRY,
+  LS_ENTRY,
 
   // Commands Files
-  INCLUDE,
-  INPUT,
-  GROUP,
-  OUTPUT,
-  SEARCH_DIR,
-  STARTUP,
+  LS_INCLUDE,
+  LS_INPUT,
+  LS_GROUP,
+  LS_OUTPUT,
+  LS_SEARCH_DIR,
+  LS_STARTUP,
 
-  INSERT,
-  AFTER,
+  LS_INSERT,
+  LS_AFTER,
 
   // Commands for object file formats
-  OUTPUT_FORMAT,
-  TARGET,
+  LS_OUTPUT_FORMAT,
+  LS_TARGET,
 
   // Other linker script commands
-  ASSERT,
-  EXTERN,
+  LS_ASSERT,
+  LS_EXTERN,
   // FORCE_COMMON_ALLOCATION
   // INHIBIT_COMMON_ALLOCATION
   // NOCROSSREFS
-  OUTPUT_ARCH,
+  LS_OUTPUT_ARCH,
 
   // Assignment
-  PROVIDE,
-  HIDDEN,
-  PROVIDE_HIDDEN,
+  LS_PROVIDE,
+  LS_HIDDEN,
+  LS_PROVIDE_HIDDEN,
 
-  SECTIONS,
+  LS_SECTIONS,
 
   // Input Section
-  EXCLUDE_FILE,
-  KEEP,
-  INPUT_SECTION_FLAGS,
+  LS_EXCLUDE_FILE,
+  LS_KEEP,
+  LS_INPUT_SECTION_FLAGS,
 
   // Read section
-  OVERLAY,
-  NOLOAD,
-  COPY,
-  INFO,
+  LS_OVERLAY,
+  LS_NOLOAD,
+  LS_COPY,
+  LS_INFO,
 
   // Output Section
-  OVERWRITE_SECTIONS,
-  SUBALIGN,
-  ONLY_IF_RO,
-  ONLY_IF_RW,
-  FILL,
-  SORT,
+  LS_OVERWRITE_SECTIONS,
+  LS_SUBALIGN,
+  LS_ONLY_IF_RO,
+  LS_ONLY_IF_RW,
+  LS_FILL,
+  LS_SORT,
 
   // Builtin Functions
-  ABSOLUTE,
-  ADDR,
-  ALIGN,
+  LS_ABSOLUTE,
+  LS_ADDR,
+  LS_ALIGN,
   // BLOCK, // synonym for ALIGN for compatibility with older linker script
-  DATA_SEGMENT_ALIGN,
-  DATA_SEGMENT_END,
-  DEFINED,
-  LOADADDR,
+  LS_DATA_SEGMENT_ALIGN,
+  LS_DATA_SEGMENT_END,
+  LS_DEFINED,
+  LS_LOADADDR,
 
-  LOG2CEIL,
-  MAX,
-  MIN,
-  ORIGIN,
-  SEGMENT_START,
+  LS_LOG2CEIL,
+  LS_MAX,
+  LS_MIN,
+  LS_ORIGIN,
+  LS_SEGMENT_START,
   // NEXT, // This function is closely related to ALIGN(exp); unless you use the
   // MEMORY command to define discontinuous memory for the output file, the two
   // functions are equivalent.
-  SIZEOF,
-  SIZEOF_HEADERS,
+  LS_SIZEOF,
+  LS_SIZEOF_HEADERS,
 
   // PHDRS Command
-  FILEHDR,
-  PHDRS,
-  AT,
-  FLAGS,
+  LS_FILEHDR,
+  LS_PHDRS,
+  LS_AT,
+  LS_FLAGS,
 
   // Version Command
-  VERSION,
+  LS_VERSION,
 
-  REGION_ALIAS,
-  AS_NEEDED,
-  CONSTRUCTORS,
+  LS_REGION_ALIAS,
+  LS_AS_NEEDED,
+  LS_CONSTRUCTORS,
 
   // Symbolic Constants
-  MAXPAGESIZE,
-  COMMONPAGESIZE,
+  LS_MAXPAGESIZE,
+  LS_COMMONPAGESIZE,
 
-  Local,  // local
-  Global, // global
-  Extern, // extern
+  LS_Local,  // local
+  LS_Global, // global
+  LS_Extern, // extern
 
-  ELF,
-  Binary,
+  LS_ELF,
+  LS_Binary,
   Error,
+  Eof,
 
   SymbolName,
   FileName,
@@ -125,7 +126,7 @@ enum class ScriptToken {
   Colon,        // :
   Asterisk,     // *
   QuestionMark, // ?
-  Bacckslash,   // "\"
+  Backslash,    // "\"
   Slash,        // /
   Greater,      // >
   Less,         // <
@@ -145,7 +146,15 @@ enum class ScriptToken {
   LeftShiftAssign,  // <<=
   RightShiftAssign, // >>=
   BitWiseAssign,    // &=
-  BarAssign         // |=
+  BarAssign,        // |=
+
+  // operator token
+  NotEqual,   // !=
+  Equal,      // ==
+  GreatEqual, // >=
+  LessEqual,  // <=
+  LeftShift,  // <<
+  RightShift, // >>
 };
 } // namespace elf
 } // namespace lld

--- a/lld/ELF/ScriptTokenizer.h
+++ b/lld/ELF/ScriptTokenizer.h
@@ -23,6 +23,7 @@ enum class ScriptToken {
   LS_INCLUDE,
   LS_INPUT,
   LS_GROUP,
+  LS_MEMORY,
   LS_OUTPUT,
   LS_SEARCH_DIR,
   LS_STARTUP,
@@ -79,6 +80,7 @@ enum class ScriptToken {
   LS_DATA_SEGMENT_ALIGN,
   LS_DATA_SEGMENT_END,
   LS_DEFINED,
+  LS_LENGTH,
   LS_LOADADDR,
 
   LS_LOG2CEIL,

--- a/lld/ELF/ScriptTokenizer.h
+++ b/lld/ELF/ScriptTokenizer.h
@@ -115,7 +115,7 @@ enum class ScriptToken {
   Error,
   Eof,
 
-  Identify,
+  Identifier,
   Hexdecimal,   // 0x
   Hexdecimal_H, // end with H/h
   Decimal,

--- a/lld/ELF/ScriptTokenizer.h
+++ b/lld/ELF/ScriptTokenizer.h
@@ -142,6 +142,8 @@ enum class ScriptToken {
   Xor,          // ^
   Or,           // |
   PercentSign,  // %
+  Underscore,   // _
+  Dot,          // .
   Quote, // Quoted token. Note that double-quote characters are parts of a token
   // because, in a glob match context, only unquoted tokens are interpreted as
   // glob patterns. Double-quoted tokens are literal patterns in that context.

--- a/lld/ELF/ScriptTokenizer.h
+++ b/lld/ELF/ScriptTokenizer.h
@@ -36,6 +36,7 @@ enum class ScriptToken {
 
   // Other linker script commands
   LS_ASSERT,
+  LS_CONSTANT,
   LS_EXTERN,
   // FORCE_COMMON_ALLOCATION
   // INHIBIT_COMMON_ALLOCATION
@@ -73,6 +74,7 @@ enum class ScriptToken {
   LS_ABSOLUTE,
   LS_ADDR,
   LS_ALIGN,
+  LS_ALIGNOF,
   // BLOCK, // synonym for ALIGN for compatibility with older linker script
   LS_DATA_SEGMENT_ALIGN,
   LS_DATA_SEGMENT_END,
@@ -152,7 +154,7 @@ enum class ScriptToken {
   // Assignmemnt
   Assign,           // =
   PlusAssign,       // +=
-  MinussAssign,     // -=
+  MinusAssign,      // -=
   MulAssign,        // *=
   DivAssign,        // /=
   LeftShiftAssign,  // <<=

--- a/lld/ELF/ScriptTokenizer.h
+++ b/lld/ELF/ScriptTokenizer.h
@@ -16,6 +16,7 @@
 namespace lld {
 namespace elf {
 enum class ScriptToken {
+  // LS stands for LinkerScript
   LS_ENTRY,
 
   // Commands Files
@@ -115,7 +116,13 @@ enum class ScriptToken {
   Eof,
 
   Identify,
+  Hexdecimal,   // 0x
+  Hexdecimal_H, // end with H/h
+  Decimal,
+  Decimal_K, // end with K/k
+  Decimal_M, // end with M/m
 
+  // Symbol tokens
   CurlyBegin,   // {
   CurlyEnd,     // }
   BracektBegin, // (
@@ -135,6 +142,9 @@ enum class ScriptToken {
   Xor,          // ^
   Or,           // |
   PercentSign,  // %
+  Quote, // Quoted token. Note that double-quote characters are parts of a token
+  // because, in a glob match context, only unquoted tokens are interpreted as
+  // glob patterns. Double-quoted tokens are literal patterns in that context.
 
   // Assignmemnt
   Assign,           // =

--- a/lld/ELF/ScriptTokenizer.h
+++ b/lld/ELF/ScriptTokenizer.h
@@ -111,6 +111,11 @@ enum class ScriptToken {
   LS_MAXPAGESIZE,
   LS_COMMONPAGESIZE,
 
+  LS_BYTE,
+  LS_SHORT,
+  LS_LONG,
+  LS_QUAD,
+
   LS_Local,  // local
   LS_Global, // global
   LS_Extern, // extern

--- a/lld/ELF/ScriptTokenizer.h
+++ b/lld/ELF/ScriptTokenizer.h
@@ -48,6 +48,7 @@ enum class ScriptToken {
   LS_PROVIDE_HIDDEN,
 
   LS_SECTIONS,
+  LS_BEFORE,
 
   // Input Section
   LS_EXCLUDE_FILE,

--- a/lld/unittests/CMakeLists.txt
+++ b/lld/unittests/CMakeLists.txt
@@ -4,3 +4,4 @@ endfunction()
 
 add_subdirectory(AsLibAll)
 add_subdirectory(AsLibELF)
+add_subdirectory(ELF)

--- a/lld/unittests/ELF/CMakeLists.txt
+++ b/lld/unittests/ELF/CMakeLists.txt
@@ -1,4 +1,7 @@
 # Test usage of LLD Linker Script Lexer
+set(LLVM_LINK_COMPONENTS
+  Support
+)
 
 add_lld_unittests(LLDELFLexerTests
   LinkerScriptLexerTest.cpp
@@ -8,4 +11,5 @@ target_link_libraries(LLDELFLexerTests
   PRIVATE
   lldELF
   lldCommon
+  LLVMTestingSupport
 )

--- a/lld/unittests/ELF/CMakeLists.txt
+++ b/lld/unittests/ELF/CMakeLists.txt
@@ -1,0 +1,11 @@
+# Test usage of LLD Linker Script Lexer
+
+add_lld_unittests(LLDELFLexerTests
+  LinkerScriptLexerTest.cpp
+)
+
+target_link_libraries(LLDELFLexerTests
+  PRIVATE
+  lldELF
+  lldCommon
+)

--- a/lld/unittests/ELF/LinkerScriptLexerTest.cpp
+++ b/lld/unittests/ELF/LinkerScriptLexerTest.cpp
@@ -1,0 +1,45 @@
+//===- lld/unittests/ELF/LinkerScriptLexerTest.cpp --------------*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "lld/ELF/LinkerScriptLexer.h"
+#include "llvm/ADT/SmallVector"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/MemoryBuff.h"
+#include "llvm/Support/SourceMgr.h"
+
+#include "gtest/gtest.h"
+
+namespace lld {
+namespace elf {
+
+class LinkerScriptLexerTest : public testing::Test {
+protected:
+  llvm::SourceMgr SrcMgr;
+  llvm::SMDiagnostic Err;
+  std::unique_ptr<LinkerScriptLexer> Lexer;
+
+  /*void setupCallToLinkScriptLexer(llvm::StringRef scriptStr) {
+    std::unique_ptr<llvm::MemoryBuffer>
+  Buffer(llvm::MemoryBuffer::getMemBuffer(scriptStr));
+    SrcMgr.AddNewSourceBuffer(std::move(Buffer), SMLoc());
+    EXPECT_EQ(Buffer, nullptr);
+
+    Lexer.reset(LinkerScriptLexer())
+  }
+
+  void lexAndCheckTokens(llvm::StringRef scriptStr,
+  llvm::SmallVector<ScriptToken> ExpectedTokens) {
+
+    for(size_t I = 0; I < ExpectedTokens.size(); ++I) {
+      EXPECTED_EQ();
+    }
+  } */
+};
+} // namespace elf
+} // namespace lld

--- a/lld/unittests/ELF/LinkerScriptLexerTest.cpp
+++ b/lld/unittests/ELF/LinkerScriptLexerTest.cpp
@@ -309,6 +309,26 @@ TEST_F(LinkerScriptLexerTest, checkAlignEmptyTest) {
   lexAndCheckTokens(ExpectedTokens);
 }
 
+TEST_F(LinkerScriptLexerTest, checkBSSFillTest) {
+  llvm::StringRef testRef = "SECTIONS {\
+                             .bss : {\
+                               . += 0x10000; \
+                               *(.bss)\
+                             } =0xFF};";
+
+  setupCallToLinkScriptLexer(testRef);
+  llvm::SmallVector<ScriptToken> ExpectedTokens(
+      {ScriptToken::LS_SECTIONS, ScriptToken::CurlyBegin,
+       ScriptToken::Identifier, ScriptToken::Colon, ScriptToken::CurlyBegin,
+       ScriptToken::Dot, ScriptToken::PlusAssign, ScriptToken::Hexdecimal,
+       ScriptToken::Semicolon, ScriptToken::Asterisk, ScriptToken::BracektBegin,
+       ScriptToken::Identifier, ScriptToken::BracektEnd, ScriptToken::CurlyEnd,
+       ScriptToken::Assign, ScriptToken::Hexdecimal, ScriptToken::CurlyEnd,
+       ScriptToken::Semicolon});
+
+  lexAndCheckTokens(ExpectedTokens);
+}
+
 TEST_F(LinkerScriptLexerTest, checkMemoryTest) {
   llvm::StringRef testRef = "MEMORY { \
   AX (ax)    : ORIGIN = 0x2000, LENGTH = 0x100 \

--- a/lld/unittests/ELF/LinkerScriptLexerTest.cpp
+++ b/lld/unittests/ELF/LinkerScriptLexerTest.cpp
@@ -103,5 +103,26 @@ TEST_F(LinkerScriptLexerTest, CheckHex) {
   lexAndCheckTokens(ExpectedTokens);
 }
 
+TEST_F(LinkerScriptLexerTest, CheckPROVIDECommand) {
+  llvm::StringRef testRef = "SECTIONS\n{.text :\n{\n*(.text)\n\t_etext = .;\n \
+                             \t PROVIDE(etext = .);\n}\n}";
+  setupCallToLinkScriptLexer(testRef);
+  llvm::SmallVector<ScriptToken> ExpectedTokens({
+      ScriptToken::LS_SECTIONS,  ScriptToken::CurlyBegin,
+      ScriptToken::Dot,          ScriptToken::Identifier,
+      ScriptToken::Colon,        ScriptToken::CurlyBegin,
+      ScriptToken::Asterisk,     ScriptToken::BracektBegin,
+      ScriptToken::Dot,          ScriptToken::Identifier,
+      ScriptToken::BracektEnd,   ScriptToken::Identifier,
+      ScriptToken::Assign,       ScriptToken::Dot,
+      ScriptToken::Semicolon,    ScriptToken::LS_PROVIDE,
+      ScriptToken::BracektBegin, ScriptToken::Identifier,
+      ScriptToken::Assign,       ScriptToken::Dot,
+      ScriptToken::BracektEnd,   ScriptToken::Semicolon,
+      ScriptToken::CurlyEnd,     ScriptToken::CurlyEnd,
+  });
+
+  lexAndCheckTokens(ExpectedTokens);
+}
 } // namespace elf
 } // namespace lld

--- a/lld/unittests/ELF/LinkerScriptLexerTest.cpp
+++ b/lld/unittests/ELF/LinkerScriptLexerTest.cpp
@@ -74,5 +74,35 @@ TEST_F(LinkerScriptLexerTest, CheckSECTIONSandALIGN) {
   lexAndCheckTokens(ExpectedTokens);
 }
 
+TEST_F(LinkerScriptLexerTest, CheckHex) {
+  llvm::StringRef testRef =
+      "SECTIONS{ \n . = 0x10000;\n .text : { *(.text) }\n \
+                           . = 0x8000000;\n .data : { *(.data) }\n .bss : { *(.bss) }}";
+  setupCallToLinkScriptLexer(testRef);
+  llvm::SmallVector<ScriptToken> ExpectedTokens(
+      {ScriptToken::LS_SECTIONS, ScriptToken::CurlyBegin,
+       ScriptToken::Dot,         ScriptToken::Assign,
+       ScriptToken::Hexdecimal,  ScriptToken::Semicolon,
+       ScriptToken::Dot,         ScriptToken::Identify,
+       ScriptToken::Colon,       ScriptToken::CurlyBegin,
+       ScriptToken::Asterisk,    ScriptToken::BracektBegin,
+       ScriptToken::Dot,         ScriptToken::Identify,
+       ScriptToken::BracektEnd,  ScriptToken::CurlyEnd,
+       ScriptToken::Dot,         ScriptToken::Assign,
+       ScriptToken::Hexdecimal,  ScriptToken::Semicolon,
+       ScriptToken::Dot,         ScriptToken::Identify,
+       ScriptToken::Colon,       ScriptToken::CurlyBegin,
+       ScriptToken::Asterisk,    ScriptToken::BracektBegin,
+       ScriptToken::Dot,         ScriptToken::Identify,
+       ScriptToken::BracektEnd,  ScriptToken::CurlyEnd,
+       ScriptToken::Dot,         ScriptToken::Identify,
+       ScriptToken::Colon,       ScriptToken::CurlyBegin,
+       ScriptToken::Asterisk,    ScriptToken::BracektBegin,
+       ScriptToken::Dot,         ScriptToken::Identify,
+       ScriptToken::BracektEnd,  ScriptToken::CurlyEnd,
+       ScriptToken::CurlyEnd});
+  lexAndCheckTokens(ExpectedTokens);
+}
+
 } // namespace elf
 } // namespace lld

--- a/lld/unittests/ELF/LinkerScriptLexerTest.cpp
+++ b/lld/unittests/ELF/LinkerScriptLexerTest.cpp
@@ -66,7 +66,7 @@ TEST_F(LinkerScriptLexerTest, CheckSECTIONSandALIGN) {
 
   setupCallToLinkScriptLexer(testRef);
   llvm::SmallVector<ScriptToken> ExpectedTokens(
-      {ScriptToken::LS_SECTIONS, ScriptToken::CurlyBegin, ScriptToken::Dot,
+      {ScriptToken::LS_SECTIONS, ScriptToken::CurlyBegin,
        ScriptToken::Identifier, ScriptToken::Colon, ScriptToken::LS_ALIGN,
        ScriptToken::BracektBegin, ScriptToken::Decimal, ScriptToken::BracektEnd,
        ScriptToken::CurlyBegin, ScriptToken::CurlyEnd, ScriptToken::CurlyEnd});
@@ -79,26 +79,23 @@ TEST_F(LinkerScriptLexerTest, CheckHex) {
                            . = 0x8000000;\n .data : { *(.data) }\n .bss : { *(.bss) }}";
   setupCallToLinkScriptLexer(testRef);
   llvm::SmallVector<ScriptToken> ExpectedTokens(
-      {ScriptToken::LS_SECTIONS, ScriptToken::CurlyBegin,
-       ScriptToken::Dot,         ScriptToken::Assign,
-       ScriptToken::Hexdecimal,  ScriptToken::Semicolon,
-       ScriptToken::Dot,         ScriptToken::Identifier,
-       ScriptToken::Colon,       ScriptToken::CurlyBegin,
-       ScriptToken::Asterisk,    ScriptToken::BracektBegin,
-       ScriptToken::Dot,         ScriptToken::Identifier,
-       ScriptToken::BracektEnd,  ScriptToken::CurlyEnd,
-       ScriptToken::Dot,         ScriptToken::Assign,
-       ScriptToken::Hexdecimal,  ScriptToken::Semicolon,
-       ScriptToken::Dot,         ScriptToken::Identifier,
-       ScriptToken::Colon,       ScriptToken::CurlyBegin,
-       ScriptToken::Asterisk,    ScriptToken::BracektBegin,
-       ScriptToken::Dot,         ScriptToken::Identifier,
-       ScriptToken::BracektEnd,  ScriptToken::CurlyEnd,
-       ScriptToken::Dot,         ScriptToken::Identifier,
-       ScriptToken::Colon,       ScriptToken::CurlyBegin,
-       ScriptToken::Asterisk,    ScriptToken::BracektBegin,
-       ScriptToken::Dot,         ScriptToken::Identifier,
-       ScriptToken::BracektEnd,  ScriptToken::CurlyEnd,
+      {ScriptToken::LS_SECTIONS,  ScriptToken::CurlyBegin,
+       ScriptToken::Dot,          ScriptToken::Assign,
+       ScriptToken::Hexdecimal,   ScriptToken::Semicolon,
+       ScriptToken::Identifier,   ScriptToken::Colon,
+       ScriptToken::CurlyBegin,   ScriptToken::Asterisk,
+       ScriptToken::BracektBegin, ScriptToken::Identifier,
+       ScriptToken::BracektEnd,   ScriptToken::CurlyEnd,
+       ScriptToken::Dot,          ScriptToken::Assign,
+       ScriptToken::Hexdecimal,   ScriptToken::Semicolon,
+       ScriptToken::Identifier,   ScriptToken::Colon,
+       ScriptToken::CurlyBegin,   ScriptToken::Asterisk,
+       ScriptToken::BracektBegin, ScriptToken::Identifier,
+       ScriptToken::BracektEnd,   ScriptToken::CurlyEnd,
+       ScriptToken::Identifier,   ScriptToken::Colon,
+       ScriptToken::CurlyBegin,   ScriptToken::Asterisk,
+       ScriptToken::BracektBegin, ScriptToken::Identifier,
+       ScriptToken::BracektEnd,   ScriptToken::CurlyEnd,
        ScriptToken::CurlyEnd});
   lexAndCheckTokens(ExpectedTokens);
 }
@@ -109,10 +106,9 @@ TEST_F(LinkerScriptLexerTest, CheckPROVIDECommand) {
   setupCallToLinkScriptLexer(testRef);
   llvm::SmallVector<ScriptToken> ExpectedTokens({
       ScriptToken::LS_SECTIONS,  ScriptToken::CurlyBegin,
-      ScriptToken::Dot,          ScriptToken::Identifier,
-      ScriptToken::Colon,        ScriptToken::CurlyBegin,
-      ScriptToken::Asterisk,     ScriptToken::BracektBegin,
-      ScriptToken::Dot,          ScriptToken::Identifier,
+      ScriptToken::Identifier,   ScriptToken::Colon,
+      ScriptToken::CurlyBegin,   ScriptToken::Asterisk,
+      ScriptToken::BracektBegin, ScriptToken::Identifier,
       ScriptToken::BracektEnd,   ScriptToken::Identifier,
       ScriptToken::Assign,       ScriptToken::Dot,
       ScriptToken::Semicolon,    ScriptToken::LS_PROVIDE,
@@ -121,6 +117,21 @@ TEST_F(LinkerScriptLexerTest, CheckPROVIDECommand) {
       ScriptToken::BracektEnd,   ScriptToken::Semicolon,
       ScriptToken::CurlyEnd,     ScriptToken::CurlyEnd,
   });
+
+  lexAndCheckTokens(ExpectedTokens);
+}
+
+TEST_F(LinkerScriptLexerTest, CheckINSERTandBEFORE) {
+  llvm::StringRef testRef =
+      "SECTIONS { .foo.data : { *(.foo.data) } } INSERT BEFORE .data;";
+  setupCallToLinkScriptLexer(testRef);
+  llvm::SmallVector<ScriptToken> ExpectedTokens(
+      {ScriptToken::LS_SECTIONS, ScriptToken::CurlyBegin,
+       ScriptToken::Identifier, ScriptToken::Colon, ScriptToken::CurlyBegin,
+       ScriptToken::Asterisk, ScriptToken::BracektBegin,
+       ScriptToken::Identifier, ScriptToken::BracektEnd, ScriptToken::CurlyEnd,
+       ScriptToken::CurlyEnd, ScriptToken::LS_INSERT, ScriptToken::LS_BEFORE,
+       ScriptToken::Identifier, ScriptToken::Semicolon});
 
   lexAndCheckTokens(ExpectedTokens);
 }

--- a/lld/unittests/ELF/LinkerScriptLexerTest.cpp
+++ b/lld/unittests/ELF/LinkerScriptLexerTest.cpp
@@ -273,11 +273,10 @@ TEST_F(LinkerScriptLexerTest, checkAddrTest) {
 
 TEST_F(LinkerScriptLexerTest, checkAlignEmptyTest) {
   llvm::StringRef testRef = "SECTIONS { \
-  . = SIZEOF_HEADERS; \
-  abc : {} \
-  . = ALIGN(0x1000); \
-  foo : { *(foo) } \
-}";
+                             . = SIZEOF_HEADERS; \
+                             abc : {} \
+                             . = ALIGN(0x1000); \
+                             foo : { *(foo) }}";
   setupCallToLinkScriptLexer(testRef);
   llvm::SmallVector<ScriptToken> ExpectedTokens({ScriptToken::LS_SECTIONS,
                                                  ScriptToken::CurlyBegin,
@@ -366,6 +365,20 @@ TEST_F(LinkerScriptLexerTest, checkMemoryTest) {
        ScriptToken::Comma,      ScriptToken::LS_LENGTH,
        ScriptToken::Assign,     ScriptToken::Hexdecimal,
 
+       ScriptToken::CurlyEnd});
+
+  lexAndCheckTokens(ExpectedTokens);
+}
+
+TEST_F(LinkerScriptLexerTest, checkCONSTRUCTORS) {
+  llvm::StringRef testRef = "SECTIONS {foo : {*(.foo) CONSTRUCTORS}}";
+  setupCallToLinkScriptLexer(testRef);
+  llvm::SmallVector<ScriptToken> ExpectedTokens(
+      {ScriptToken::LS_SECTIONS, ScriptToken::CurlyBegin,
+       ScriptToken::Identifier, ScriptToken::Colon, ScriptToken::CurlyBegin,
+       ScriptToken::Asterisk, ScriptToken::BracektBegin,
+       ScriptToken::Identifier, ScriptToken::BracektEnd,
+       ScriptToken::LS_CONSTRUCTORS, ScriptToken::CurlyEnd,
        ScriptToken::CurlyEnd});
 
   lexAndCheckTokens(ExpectedTokens);

--- a/lld/unittests/ELF/LinkerScriptLexerTest.cpp
+++ b/lld/unittests/ELF/LinkerScriptLexerTest.cpp
@@ -219,5 +219,23 @@ TEST_F(LinkerScriptLexerTest, CheckAbsoluteExprTest) {
   lexAndCheckTokens(ExpectedTokens);
 }
 
+TEST_F(LinkerScriptLexerTest, checkAddrZeroTest) {
+  llvm::StringRef testRef = "SECTIONS {\
+  foo = ADDR(.text) - ABSOLUTE(ADDR(.text));\
+};";
+  setupCallToLinkScriptLexer(testRef);
+  llvm::SmallVector<ScriptToken> ExpectedTokens(
+      {ScriptToken::LS_SECTIONS, ScriptToken::CurlyBegin,
+       ScriptToken::Identifier, ScriptToken::Assign, ScriptToken::LS_ADDR,
+       ScriptToken::BracektBegin, ScriptToken::Identifier,
+       ScriptToken::BracektEnd, ScriptToken::Minus, ScriptToken::LS_ABSOLUTE,
+       ScriptToken::BracektBegin, ScriptToken::LS_ADDR,
+       ScriptToken::BracektBegin, ScriptToken::Identifier,
+       ScriptToken::BracektEnd, ScriptToken::BracektEnd, ScriptToken::Semicolon,
+       ScriptToken::CurlyEnd});
+
+  lexAndCheckTokens(ExpectedTokens);
+}
+
 } // namespace elf
 } // namespace lld

--- a/lld/unittests/ELF/LinkerScriptLexerTest.cpp
+++ b/lld/unittests/ELF/LinkerScriptLexerTest.cpp
@@ -149,5 +149,75 @@ TEST_F(LinkerScriptLexerTest, CheckALIGNandDecimal) {
 
   lexAndCheckTokens(ExpectedTokens);
 }
+
+TEST_F(LinkerScriptLexerTest, CheckAbsoluteExprTest) {
+  llvm::StringRef testRef = "SECTIONS { \
+  .text : { \
+    bar1 = ALIGNOF(.text); \
+    bar2 = CONSTANT (MAXPAGESIZE); \
+    bar3 = SIZEOF (.text); \
+    bar4 = SIZEOF_HEADERS; \
+    bar5 = 0x42; \
+    bar6 = foo + 1; \
+    *(.text) \
+  } \
+}";
+  setupCallToLinkScriptLexer(testRef);
+  llvm::SmallVector<ScriptToken> ExpectedTokens({ScriptToken::LS_SECTIONS,
+                                                 ScriptToken::CurlyBegin,
+                                                 ScriptToken::Identifier,
+                                                 ScriptToken::Colon,
+                                                 ScriptToken::CurlyBegin,
+                                                 ScriptToken::Identifier,
+                                                 ScriptToken::Assign,
+                                                 ScriptToken::LS_ALIGNOF,
+                                                 ScriptToken::BracektBegin,
+                                                 ScriptToken::Identifier,
+                                                 ScriptToken::BracektEnd,
+                                                 ScriptToken::Semicolon,
+
+                                                 ScriptToken::Identifier,
+                                                 ScriptToken::Assign,
+                                                 ScriptToken::LS_CONSTANT,
+                                                 ScriptToken::BracektBegin,
+                                                 ScriptToken::LS_MAXPAGESIZE,
+                                                 ScriptToken::BracektEnd,
+                                                 ScriptToken::Semicolon,
+
+                                                 ScriptToken::Identifier,
+                                                 ScriptToken::Assign,
+                                                 ScriptToken::LS_SIZEOF,
+                                                 ScriptToken::BracektBegin,
+                                                 ScriptToken::Identifier,
+                                                 ScriptToken::BracektEnd,
+                                                 ScriptToken::Semicolon,
+
+                                                 ScriptToken::Identifier,
+                                                 ScriptToken::Assign,
+                                                 ScriptToken::LS_SIZEOF_HEADERS,
+                                                 ScriptToken::Semicolon,
+
+                                                 ScriptToken::Identifier,
+                                                 ScriptToken::Assign,
+                                                 ScriptToken::Hexdecimal,
+                                                 ScriptToken::Semicolon,
+
+                                                 ScriptToken::Identifier,
+                                                 ScriptToken::Assign,
+                                                 ScriptToken::Identifier,
+                                                 ScriptToken::Plus,
+                                                 ScriptToken::Decimal,
+                                                 ScriptToken::Semicolon,
+
+                                                 ScriptToken::Asterisk,
+                                                 ScriptToken::BracektBegin,
+                                                 ScriptToken::Identifier,
+                                                 ScriptToken::BracektEnd,
+                                                 ScriptToken::CurlyEnd,
+                                                 ScriptToken::CurlyEnd});
+
+  lexAndCheckTokens(ExpectedTokens);
+}
+
 } // namespace elf
 } // namespace lld

--- a/lld/unittests/ELF/LinkerScriptLexerTest.cpp
+++ b/lld/unittests/ELF/LinkerScriptLexerTest.cpp
@@ -480,5 +480,27 @@ TEST_F(LinkerScriptLexerTest, checkDataCommands) {
   lexAndCheckTokens(ExpectedTokens);
 }
 
+TEST_F(LinkerScriptLexerTest, checkDefinedTest) {
+  llvm::StringRef testRef = "EXTERN(extern_defined) \nSECTIONS { . = \
+                             DEFINED(defined) ? 0x11000 : .;.foo : { *(.foo*) }";
+  setupCallToLinkScriptLexer(testRef);
+  llvm::SmallVector<ScriptToken> ExpectedTokens(
+      {ScriptToken::LS_EXTERN,    ScriptToken::BracektBegin,
+       ScriptToken::Identifier,   ScriptToken::BracektEnd,
+       ScriptToken::LS_SECTIONS,  ScriptToken::CurlyBegin,
+       ScriptToken::Dot,          ScriptToken::Assign,
+       ScriptToken::LS_DEFINED,   ScriptToken::BracektBegin,
+       ScriptToken::Identifier,   ScriptToken::BracektEnd,
+       ScriptToken::QuestionMark, ScriptToken::Hexdecimal,
+       ScriptToken::Colon,        ScriptToken::Dot,
+       ScriptToken::Semicolon,    ScriptToken::Identifier,
+       ScriptToken::Colon,        ScriptToken::CurlyBegin,
+       ScriptToken::Asterisk,     ScriptToken::BracektBegin,
+       ScriptToken::Identifier,   ScriptToken::BracektEnd,
+       ScriptToken::CurlyEnd});
+
+  lexAndCheckTokens(ExpectedTokens);
+}
+
 } // namespace elf
 } // namespace lld

--- a/lld/unittests/ELF/LinkerScriptLexerTest.cpp
+++ b/lld/unittests/ELF/LinkerScriptLexerTest.cpp
@@ -55,8 +55,7 @@ TEST_F(LinkerScriptLexerTest, CheckEntryLabel) {
   llvm::StringRef testRef = "ENTRY(_label)";
   setupCallToLinkScriptLexer(testRef);
   llvm::SmallVector<ScriptToken> ExpectedTokens(
-      {ScriptToken::LS_ENTRY, ScriptToken::BracektBegin,
-       ScriptToken::Underscore, ScriptToken::Identify,
+      {ScriptToken::LS_ENTRY, ScriptToken::BracektBegin, ScriptToken::Identify,
        ScriptToken::BracektEnd});
   lexAndCheckTokens(ExpectedTokens);
 }

--- a/lld/unittests/ELF/LinkerScriptLexerTest.cpp
+++ b/lld/unittests/ELF/LinkerScriptLexerTest.cpp
@@ -55,8 +55,8 @@ TEST_F(LinkerScriptLexerTest, CheckEntryLabel) {
   llvm::StringRef testRef = "ENTRY(_label)";
   setupCallToLinkScriptLexer(testRef);
   llvm::SmallVector<ScriptToken> ExpectedTokens(
-      {ScriptToken::LS_ENTRY, ScriptToken::BracektBegin, ScriptToken::Identify,
-       ScriptToken::BracektEnd});
+      {ScriptToken::LS_ENTRY, ScriptToken::BracektBegin,
+       ScriptToken::Identifier, ScriptToken::BracektEnd});
   lexAndCheckTokens(ExpectedTokens);
 }
 
@@ -67,7 +67,7 @@ TEST_F(LinkerScriptLexerTest, CheckSECTIONSandALIGN) {
   setupCallToLinkScriptLexer(testRef);
   llvm::SmallVector<ScriptToken> ExpectedTokens(
       {ScriptToken::LS_SECTIONS, ScriptToken::CurlyBegin, ScriptToken::Dot,
-       ScriptToken::Identify, ScriptToken::Colon, ScriptToken::LS_ALIGN,
+       ScriptToken::Identifier, ScriptToken::Colon, ScriptToken::LS_ALIGN,
        ScriptToken::BracektBegin, ScriptToken::Decimal, ScriptToken::BracektEnd,
        ScriptToken::CurlyBegin, ScriptToken::CurlyEnd, ScriptToken::CurlyEnd});
   lexAndCheckTokens(ExpectedTokens);
@@ -82,22 +82,22 @@ TEST_F(LinkerScriptLexerTest, CheckHex) {
       {ScriptToken::LS_SECTIONS, ScriptToken::CurlyBegin,
        ScriptToken::Dot,         ScriptToken::Assign,
        ScriptToken::Hexdecimal,  ScriptToken::Semicolon,
-       ScriptToken::Dot,         ScriptToken::Identify,
+       ScriptToken::Dot,         ScriptToken::Identifier,
        ScriptToken::Colon,       ScriptToken::CurlyBegin,
        ScriptToken::Asterisk,    ScriptToken::BracektBegin,
-       ScriptToken::Dot,         ScriptToken::Identify,
+       ScriptToken::Dot,         ScriptToken::Identifier,
        ScriptToken::BracektEnd,  ScriptToken::CurlyEnd,
        ScriptToken::Dot,         ScriptToken::Assign,
        ScriptToken::Hexdecimal,  ScriptToken::Semicolon,
-       ScriptToken::Dot,         ScriptToken::Identify,
+       ScriptToken::Dot,         ScriptToken::Identifier,
        ScriptToken::Colon,       ScriptToken::CurlyBegin,
        ScriptToken::Asterisk,    ScriptToken::BracektBegin,
-       ScriptToken::Dot,         ScriptToken::Identify,
+       ScriptToken::Dot,         ScriptToken::Identifier,
        ScriptToken::BracektEnd,  ScriptToken::CurlyEnd,
-       ScriptToken::Dot,         ScriptToken::Identify,
+       ScriptToken::Dot,         ScriptToken::Identifier,
        ScriptToken::Colon,       ScriptToken::CurlyBegin,
        ScriptToken::Asterisk,    ScriptToken::BracektBegin,
-       ScriptToken::Dot,         ScriptToken::Identify,
+       ScriptToken::Dot,         ScriptToken::Identifier,
        ScriptToken::BracektEnd,  ScriptToken::CurlyEnd,
        ScriptToken::CurlyEnd});
   lexAndCheckTokens(ExpectedTokens);

--- a/lld/unittests/ELF/LinkerScriptLexerTest.cpp
+++ b/lld/unittests/ELF/LinkerScriptLexerTest.cpp
@@ -163,58 +163,33 @@ TEST_F(LinkerScriptLexerTest, CheckAbsoluteExprTest) {
   } \
 }";
   setupCallToLinkScriptLexer(testRef);
-  llvm::SmallVector<ScriptToken> ExpectedTokens({ScriptToken::LS_SECTIONS,
-                                                 ScriptToken::CurlyBegin,
-                                                 ScriptToken::Identifier,
-                                                 ScriptToken::Colon,
-                                                 ScriptToken::CurlyBegin,
-                                                 ScriptToken::Identifier,
-                                                 ScriptToken::Assign,
-                                                 ScriptToken::LS_ALIGNOF,
-                                                 ScriptToken::BracektBegin,
-                                                 ScriptToken::Identifier,
-                                                 ScriptToken::BracektEnd,
-                                                 ScriptToken::Semicolon,
+  llvm::SmallVector<ScriptToken> ExpectedTokens(
+      {ScriptToken::LS_SECTIONS,    ScriptToken::CurlyBegin,
+       ScriptToken::Identifier,     ScriptToken::Colon,
+       ScriptToken::CurlyBegin,     ScriptToken::Identifier,
+       ScriptToken::Assign,         ScriptToken::LS_ALIGNOF,
+       ScriptToken::BracektBegin,   ScriptToken::Identifier,
+       ScriptToken::BracektEnd,     ScriptToken::Semicolon,
 
-                                                 ScriptToken::Identifier,
-                                                 ScriptToken::Assign,
-                                                 ScriptToken::LS_CONSTANT,
-                                                 ScriptToken::BracektBegin,
-                                                 ScriptToken::LS_MAXPAGESIZE,
-                                                 ScriptToken::BracektEnd,
-                                                 ScriptToken::Semicolon,
+       ScriptToken::Identifier,     ScriptToken::Assign,
+       ScriptToken::LS_CONSTANT,    ScriptToken::BracektBegin,
+       ScriptToken::LS_MAXPAGESIZE, ScriptToken::BracektEnd,
+       ScriptToken::Semicolon,
 
-                                                 ScriptToken::Identifier,
-                                                 ScriptToken::Assign,
-                                                 ScriptToken::LS_SIZEOF,
-                                                 ScriptToken::BracektBegin,
-                                                 ScriptToken::Identifier,
-                                                 ScriptToken::BracektEnd,
-                                                 ScriptToken::Semicolon,
+       ScriptToken::Identifier,     ScriptToken::Assign,
+       ScriptToken::LS_SIZEOF,      ScriptToken::BracektBegin,
+       ScriptToken::Identifier,     ScriptToken::BracektEnd,
+       ScriptToken::Semicolon,      ScriptToken::Identifier,
+       ScriptToken::Assign,         ScriptToken::LS_SIZEOF_HEADERS,
 
-                                                 ScriptToken::Identifier,
-                                                 ScriptToken::Assign,
-                                                 ScriptToken::LS_SIZEOF_HEADERS,
-                                                 ScriptToken::Semicolon,
-
-                                                 ScriptToken::Identifier,
-                                                 ScriptToken::Assign,
-                                                 ScriptToken::Hexdecimal,
-                                                 ScriptToken::Semicolon,
-
-                                                 ScriptToken::Identifier,
-                                                 ScriptToken::Assign,
-                                                 ScriptToken::Identifier,
-                                                 ScriptToken::Plus,
-                                                 ScriptToken::Decimal,
-                                                 ScriptToken::Semicolon,
-
-                                                 ScriptToken::Asterisk,
-                                                 ScriptToken::BracektBegin,
-                                                 ScriptToken::Identifier,
-                                                 ScriptToken::BracektEnd,
-                                                 ScriptToken::CurlyEnd,
-                                                 ScriptToken::CurlyEnd});
+       ScriptToken::Identifier,     ScriptToken::Assign,
+       ScriptToken::Hexdecimal,     ScriptToken::Semicolon,
+       ScriptToken::Identifier,     ScriptToken::Assign,
+       ScriptToken::Identifier,     ScriptToken::Plus,
+       ScriptToken::Decimal,        ScriptToken::Semicolon,
+       ScriptToken::Asterisk,       ScriptToken::BracektBegin,
+       ScriptToken::Identifier,     ScriptToken::BracektEnd,
+       ScriptToken::CurlyEnd,       ScriptToken::CurlyEnd});
 
   lexAndCheckTokens(ExpectedTokens);
 }
@@ -237,5 +212,62 @@ TEST_F(LinkerScriptLexerTest, checkAddrZeroTest) {
   lexAndCheckTokens(ExpectedTokens);
 }
 
+TEST_F(LinkerScriptLexerTest, checkAddrTest) {
+  llvm::StringRef testRef = "SECTIONS {\
+  . = 0x1000; \
+  .text  : { \
+    *(.text*) \
+    x1 = ADDR(.text) + 1; x2 = 1 + ADDR(.text);\
+    x3 = ADDR(.text) & 0xffff;\
+  }\
+  .foo-1 : { *(.foo-1) }\
+  .foo-2 ADDR(.foo-1) + 0x100 : { *(.foo-2) }\
+  .foo-3 : { *(.foo-3) }\
+}";
+
+  setupCallToLinkScriptLexer(testRef);
+  llvm::SmallVector<ScriptToken> ExpectedTokens(
+      {ScriptToken::LS_SECTIONS,  ScriptToken::CurlyBegin,
+       ScriptToken::Dot,          ScriptToken::Assign,
+       ScriptToken::Hexdecimal,   ScriptToken::Semicolon,
+       ScriptToken::Identifier,   ScriptToken::Colon,
+       ScriptToken::CurlyBegin,   ScriptToken::Asterisk,
+       ScriptToken::BracektBegin, ScriptToken::Identifier,
+       ScriptToken::BracektEnd,   ScriptToken::Identifier,
+       ScriptToken::Assign,       ScriptToken::LS_ADDR,
+       ScriptToken::BracektBegin, ScriptToken::Identifier,
+       ScriptToken::BracektEnd,   ScriptToken::Plus,
+       ScriptToken::Decimal,      ScriptToken::Semicolon,
+
+       ScriptToken::Identifier,   ScriptToken::Assign,
+       ScriptToken::Decimal,      ScriptToken::Plus,
+       ScriptToken::LS_ADDR,      ScriptToken::BracektBegin,
+       ScriptToken::Identifier,   ScriptToken::BracektEnd,
+       ScriptToken::Semicolon,    ScriptToken::Identifier,
+       ScriptToken::Assign,       ScriptToken::LS_ADDR,
+       ScriptToken::BracektBegin, ScriptToken::Identifier,
+       ScriptToken::BracektEnd,   ScriptToken::Bitwise,
+       ScriptToken::Hexdecimal,   ScriptToken::Semicolon,
+       ScriptToken::CurlyEnd,
+
+       ScriptToken::Identifier,   ScriptToken::Colon,
+       ScriptToken::CurlyBegin,   ScriptToken::Asterisk,
+       ScriptToken::BracektBegin, ScriptToken::Identifier,
+       ScriptToken::BracektEnd,   ScriptToken::CurlyEnd,
+       ScriptToken::Identifier,   ScriptToken::LS_ADDR,
+       ScriptToken::BracektBegin, ScriptToken::Identifier,
+       ScriptToken::BracektEnd,   ScriptToken::Plus,
+       ScriptToken::Hexdecimal,   ScriptToken::Colon,
+       ScriptToken::CurlyBegin,   ScriptToken::Asterisk,
+       ScriptToken::BracektBegin, ScriptToken::Identifier,
+       ScriptToken::BracektEnd,   ScriptToken::CurlyEnd,
+       ScriptToken::Identifier,   ScriptToken::Colon,
+       ScriptToken::CurlyBegin,   ScriptToken::Asterisk,
+       ScriptToken::BracektBegin, ScriptToken::Identifier,
+       ScriptToken::BracektEnd,   ScriptToken::CurlyEnd,
+       ScriptToken::CurlyEnd});
+
+  lexAndCheckTokens(ExpectedTokens);
+}
 } // namespace elf
 } // namespace lld

--- a/lld/unittests/ELF/LinkerScriptLexerTest.cpp
+++ b/lld/unittests/ELF/LinkerScriptLexerTest.cpp
@@ -135,5 +135,19 @@ TEST_F(LinkerScriptLexerTest, CheckINSERTandBEFORE) {
 
   lexAndCheckTokens(ExpectedTokens);
 }
+
+TEST_F(LinkerScriptLexerTest, CheckALIGNandDecimal) {
+  llvm::StringRef testRef = "SECTIONS {.foo : ALIGN(2M) { *(.foo) }}";
+  setupCallToLinkScriptLexer(testRef);
+  llvm::SmallVector<ScriptToken> ExpectedTokens(
+      {ScriptToken::LS_SECTIONS, ScriptToken::CurlyBegin,
+       ScriptToken::Identifier, ScriptToken::Colon, ScriptToken::LS_ALIGN,
+       ScriptToken::BracektBegin, ScriptToken::Decimal_M,
+       ScriptToken::BracektEnd, ScriptToken::CurlyBegin, ScriptToken::Asterisk,
+       ScriptToken::BracektBegin, ScriptToken::Identifier,
+       ScriptToken::BracektEnd, ScriptToken::CurlyEnd, ScriptToken::CurlyEnd});
+
+  lexAndCheckTokens(ExpectedTokens);
+}
 } // namespace elf
 } // namespace lld

--- a/lld/unittests/ELF/LinkerScriptLexerTest.cpp
+++ b/lld/unittests/ELF/LinkerScriptLexerTest.cpp
@@ -384,5 +384,101 @@ TEST_F(LinkerScriptLexerTest, checkCONSTRUCTORS) {
   lexAndCheckTokens(ExpectedTokens);
 }
 
+TEST_F(LinkerScriptLexerTest, checkDataCommands) {
+  // this test case comes from lld/test/ELF/linkerscript/data-commands2.test
+  llvm::StringRef testRef = "MEMORY {\
+                              rom (rwx) : ORIGIN = 0x00, LENGTH = 2K\
+                             } \
+                             SECTIONS {\
+                               .foo : {\
+                                *(.foo.1) \
+                                BYTE(0x11)\
+                                *(.foo.2)\
+                                SHORT(0x1122)\
+                                *(.foo.3)\
+                                LONG(0x11223344)\
+                                *(.foo.4)\
+                                QUAD(0x1122334455667788)\
+                               } > rom \
+                              .bar : { \
+                                *(.bar.1) \
+                                BYTE(a + 1) \
+                                *(.bar.2) \
+                                SHORT(b) \
+                                *(.bar.3) \
+                                LONG(c + 2) \
+                                *(.bar.4) \
+                                QUAD(d) \
+                              } > rom}";
+
+  setupCallToLinkScriptLexer(testRef);
+  llvm::SmallVector<ScriptToken> ExpectedTokens(
+      {ScriptToken::LS_MEMORY,   ScriptToken::CurlyBegin,
+       ScriptToken::Identifier,  ScriptToken::BracektBegin,
+       ScriptToken::Identifier,  ScriptToken::BracektEnd,
+       ScriptToken::Colon,       ScriptToken::LS_ORIGIN,
+       ScriptToken::Assign,      ScriptToken::Hexdecimal,
+       ScriptToken::Comma,       ScriptToken::LS_LENGTH,
+       ScriptToken::Assign,      ScriptToken::Decimal_K,
+       ScriptToken::CurlyEnd,
+
+       ScriptToken::LS_SECTIONS, ScriptToken::CurlyBegin,
+       ScriptToken::Identifier,  ScriptToken::Colon,
+       ScriptToken::CurlyBegin,
+
+       ScriptToken::Asterisk,    ScriptToken::BracektBegin,
+       ScriptToken::Identifier,  ScriptToken::BracektEnd,
+       ScriptToken::LS_BYTE,     ScriptToken::BracektBegin,
+       ScriptToken::Hexdecimal,  ScriptToken::BracektEnd,
+
+       ScriptToken::Asterisk,    ScriptToken::BracektBegin,
+       ScriptToken::Identifier,  ScriptToken::BracektEnd,
+       ScriptToken::LS_SHORT,    ScriptToken::BracektBegin,
+       ScriptToken::Hexdecimal,  ScriptToken::BracektEnd,
+
+       ScriptToken::Asterisk,    ScriptToken::BracektBegin,
+       ScriptToken::Identifier,  ScriptToken::BracektEnd,
+       ScriptToken::LS_LONG,     ScriptToken::BracektBegin,
+       ScriptToken::Hexdecimal,  ScriptToken::BracektEnd,
+
+       ScriptToken::Asterisk,    ScriptToken::BracektBegin,
+       ScriptToken::Identifier,  ScriptToken::BracektEnd,
+       ScriptToken::LS_QUAD,     ScriptToken::BracektBegin,
+       ScriptToken::Hexdecimal,  ScriptToken::BracektEnd,
+
+       ScriptToken::CurlyEnd,    ScriptToken::Greater,
+       ScriptToken::Identifier,
+
+       ScriptToken::Identifier,  ScriptToken::Colon,
+       ScriptToken::CurlyBegin,
+
+       ScriptToken::Asterisk,    ScriptToken::BracektBegin,
+       ScriptToken::Identifier,  ScriptToken::BracektEnd,
+       ScriptToken::LS_BYTE,     ScriptToken::BracektBegin,
+       ScriptToken::Identifier,  ScriptToken::Plus,
+       ScriptToken::Decimal,     ScriptToken::BracektEnd,
+
+       ScriptToken::Asterisk,    ScriptToken::BracektBegin,
+       ScriptToken::Identifier,  ScriptToken::BracektEnd,
+       ScriptToken::LS_SHORT,    ScriptToken::BracektBegin,
+       ScriptToken::Identifier,  ScriptToken::BracektEnd,
+
+       ScriptToken::Asterisk,    ScriptToken::BracektBegin,
+       ScriptToken::Identifier,  ScriptToken::BracektEnd,
+       ScriptToken::LS_LONG,     ScriptToken::BracektBegin,
+       ScriptToken::Identifier,  ScriptToken::Plus,
+       ScriptToken::Decimal,     ScriptToken::BracektEnd,
+
+       ScriptToken::Asterisk,    ScriptToken::BracektBegin,
+       ScriptToken::Identifier,  ScriptToken::BracektEnd,
+       ScriptToken::LS_QUAD,     ScriptToken::BracektBegin,
+       ScriptToken::Identifier,  ScriptToken::BracektEnd,
+
+       ScriptToken::CurlyEnd,    ScriptToken::Greater,
+       ScriptToken::Identifier,  ScriptToken::CurlyEnd});
+
+  lexAndCheckTokens(ExpectedTokens);
+}
+
 } // namespace elf
 } // namespace lld

--- a/lld/unittests/ELF/LinkerScriptLexerTest.cpp
+++ b/lld/unittests/ELF/LinkerScriptLexerTest.cpp
@@ -308,5 +308,48 @@ TEST_F(LinkerScriptLexerTest, checkAlignEmptyTest) {
 
   lexAndCheckTokens(ExpectedTokens);
 }
+
+TEST_F(LinkerScriptLexerTest, checkMemoryTest) {
+  llvm::StringRef testRef = "MEMORY { \
+  AX (ax)    : ORIGIN = 0x2000, LENGTH = 0x100 \
+  AW (aw)    : ORIGIN = 0x3000, LENGTH = 0x100 \
+  FLASH (ax) : ORIGIN = 0x6000, LENGTH = 0x100 \
+  RAM (aw)   : ORIGIN = 0x7000, LENGTH = 0x100}";
+  setupCallToLinkScriptLexer(testRef);
+  llvm::SmallVector<ScriptToken> ExpectedTokens(
+      {ScriptToken::LS_MEMORY,  ScriptToken::CurlyBegin,
+       ScriptToken::Identifier, ScriptToken::BracektBegin,
+       ScriptToken::Identifier, ScriptToken::BracektEnd,
+       ScriptToken::Colon,      ScriptToken::LS_ORIGIN,
+       ScriptToken::Assign,     ScriptToken::Hexdecimal,
+       ScriptToken::Comma,      ScriptToken::LS_LENGTH,
+       ScriptToken::Assign,     ScriptToken::Hexdecimal,
+
+       ScriptToken::Identifier, ScriptToken::BracektBegin,
+       ScriptToken::Identifier, ScriptToken::BracektEnd,
+       ScriptToken::Colon,      ScriptToken::LS_ORIGIN,
+       ScriptToken::Assign,     ScriptToken::Hexdecimal,
+       ScriptToken::Comma,      ScriptToken::LS_LENGTH,
+       ScriptToken::Assign,     ScriptToken::Hexdecimal,
+
+       ScriptToken::Identifier, ScriptToken::BracektBegin,
+       ScriptToken::Identifier, ScriptToken::BracektEnd,
+       ScriptToken::Colon,      ScriptToken::LS_ORIGIN,
+       ScriptToken::Assign,     ScriptToken::Hexdecimal,
+       ScriptToken::Comma,      ScriptToken::LS_LENGTH,
+       ScriptToken::Assign,     ScriptToken::Hexdecimal,
+
+       ScriptToken::Identifier, ScriptToken::BracektBegin,
+       ScriptToken::Identifier, ScriptToken::BracektEnd,
+       ScriptToken::Colon,      ScriptToken::LS_ORIGIN,
+       ScriptToken::Assign,     ScriptToken::Hexdecimal,
+       ScriptToken::Comma,      ScriptToken::LS_LENGTH,
+       ScriptToken::Assign,     ScriptToken::Hexdecimal,
+
+       ScriptToken::CurlyEnd});
+
+  lexAndCheckTokens(ExpectedTokens);
+}
+
 } // namespace elf
 } // namespace lld

--- a/lld/unittests/ELF/LinkerScriptLexerTest.cpp
+++ b/lld/unittests/ELF/LinkerScriptLexerTest.cpp
@@ -181,6 +181,7 @@ TEST_F(LinkerScriptLexerTest, CheckAbsoluteExprTest) {
        ScriptToken::Identifier,     ScriptToken::BracektEnd,
        ScriptToken::Semicolon,      ScriptToken::Identifier,
        ScriptToken::Assign,         ScriptToken::LS_SIZEOF_HEADERS,
+       ScriptToken::Semicolon,
 
        ScriptToken::Identifier,     ScriptToken::Assign,
        ScriptToken::Hexdecimal,     ScriptToken::Semicolon,
@@ -266,6 +267,44 @@ TEST_F(LinkerScriptLexerTest, checkAddrTest) {
        ScriptToken::BracektBegin, ScriptToken::Identifier,
        ScriptToken::BracektEnd,   ScriptToken::CurlyEnd,
        ScriptToken::CurlyEnd});
+
+  lexAndCheckTokens(ExpectedTokens);
+}
+
+TEST_F(LinkerScriptLexerTest, checkAlignEmptyTest) {
+  llvm::StringRef testRef = "SECTIONS { \
+  . = SIZEOF_HEADERS; \
+  abc : {} \
+  . = ALIGN(0x1000); \
+  foo : { *(foo) } \
+}";
+  setupCallToLinkScriptLexer(testRef);
+  llvm::SmallVector<ScriptToken> ExpectedTokens({ScriptToken::LS_SECTIONS,
+                                                 ScriptToken::CurlyBegin,
+                                                 ScriptToken::Dot,
+                                                 ScriptToken::Assign,
+                                                 ScriptToken::LS_SIZEOF_HEADERS,
+                                                 ScriptToken::Semicolon,
+                                                 ScriptToken::Identifier,
+                                                 ScriptToken::Colon,
+                                                 ScriptToken::CurlyBegin,
+                                                 ScriptToken::CurlyEnd,
+                                                 ScriptToken::Dot,
+                                                 ScriptToken::Assign,
+                                                 ScriptToken::LS_ALIGN,
+                                                 ScriptToken::BracektBegin,
+                                                 ScriptToken::Hexdecimal,
+                                                 ScriptToken::BracektEnd,
+                                                 ScriptToken::Semicolon,
+                                                 ScriptToken::Identifier,
+                                                 ScriptToken::Colon,
+                                                 ScriptToken::CurlyBegin,
+                                                 ScriptToken::Asterisk,
+                                                 ScriptToken::BracektBegin,
+                                                 ScriptToken::Identifier,
+                                                 ScriptToken::BracektEnd,
+                                                 ScriptToken::CurlyEnd,
+                                                 ScriptToken::CurlyEnd});
 
   lexAndCheckTokens(ExpectedTokens);
 }

--- a/lld/unittests/ELF/LinkerScriptLexerTest.cpp
+++ b/lld/unittests/ELF/LinkerScriptLexerTest.cpp
@@ -6,12 +6,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "lld/ELF/LinkerScriptLexer.h"
+#include "../ELF/LinkerScriptLexer.h"
 #include "llvm/ADT/SmallVector"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/MemoryBuff.h"
-#include "llvm/Support/SourceMgr.h"
 
 #include "gtest/gtest.h"
 
@@ -20,26 +19,27 @@ namespace elf {
 
 class LinkerScriptLexerTest : public testing::Test {
 protected:
-  llvm::SourceMgr SrcMgr;
-  llvm::SMDiagnostic Err;
   std::unique_ptr<LinkerScriptLexer> Lexer;
+  std::unique_ptr<MemoryBuffer> Buffer;
 
-  /*void setupCallToLinkScriptLexer(llvm::StringRef scriptStr) {
-    std::unique_ptr<llvm::MemoryBuffer>
-  Buffer(llvm::MemoryBuffer::getMemBuffer(scriptStr));
-    SrcMgr.AddNewSourceBuffer(std::move(Buffer), SMLoc());
-    EXPECT_EQ(Buffer, nullptr);
-
-    Lexer.reset(LinkerScriptLexer())
+  void setupCallToLinkScriptLexer(llvm::StringRef scriptStr) {
+    Buffer.reset(llvm::MemoryBuffer::getMemBuffer(scriptStr));
+    Lexer.reset(LinkerScriptLexer(Buffer->getMemBufferRef()))
   }
 
-  void lexAndCheckTokens(llvm::StringRef scriptStr,
-  llvm::SmallVector<ScriptToken> ExpectedTokens) {
-
-    for(size_t I = 0; I < ExpectedTokens.size(); ++I) {
-      EXPECTED_EQ();
+  void lexAndCheckTokens(llvm::SmallVector<ScriptToken> ExpectedTokens) {
+    for (const auto &expected : ExpectedTokens) {
+      Lexer->advanceLexer();
+      EXPECTED_EQ(Lexer->getTokenKind, expected);
     }
-  } */
+  }
 };
+
+TEST(LinkerScriptLexerTest, CheckEntry) {
+  llvm::StringRef testRef = "      ENTRY";
+  setupCallToLinkScriptLexer(testRef);
+  llvm::SmallVector<ScriptToken> ExpectedTokens({ScriptToken::ENTRY});
+  lexAndCheckTokens(ExpectedTokens);
+}
 } // namespace elf
 } // namespace lld


### PR DESCRIPTION
The linker script's grammar is not complex but ambiguous due to the lack of the formal specification of the language. What we are trying to do in this and other files in LLD is to make a "reasonable" linker script processor.

Current goal:
* create a new lexer that is totally separate from LLD
* Hook it up with the existing parser 
* create unit test for linker script lexer/parser
* quality of diagnostic messages 
* performance improvements

We also should:
* start by defining the API
* potential design change for parser